### PR TITLE
Set default value for upload.verify

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -97,6 +97,8 @@ tools.avrdude.config.path={runtime.platform.path}/avrdude.conf
 
 tools.avrdude.upload.params.verbose=-v
 tools.avrdude.upload.params.quiet=-q -q
+# tools.avrdude.upload.verify is needed for backwards compatibility with AVRDUDE 6.3.0 and IDE 1.6.8 or older, IDE 1.6.9 or newer overrides this value
+tools.avrdude.upload.verify=
 tools.avrdude.upload.params.noverify=-V
 tools.avrdude.upload.pattern="{cmd.path}" "-C{config.path}" {upload.verbose} {upload.verify} -p{build.mcu} -c{upload.protocol} -P{serial.port} -b{upload.speed} -D "-Uflash:w:{build.path}/{build.project_name}.hex:i"
 


### PR DESCRIPTION
The purpose of this pull request is to provide **Upload** compatibility with Arduino IDE 1.6.8 or older and Arduino AVR Boards 1.6.12 or 1.6.14.

Steps to reproduce the issue solved by this pull request:
- Start Arduino IDE 1.6.8 or older
- Install Arduino AVR Boards 1.6.14
- Select a MiniCore board
- Upload

Arduino IDE 1.6.9 and newer allow the -V option to be added to the AVRDUDE command if **File > Preferences Verify code after upload** is unchecked. In previous versions of the IDE this option had no effect, going back for some time. As with many changes made to the IDE, this broke backwards compatibility, though in this case there was some delay.

Arduino AVR Boards 1.6.11 added the `{upload.verify}` property to the `tools.avrdude.upload` recipe to support the **File > Preferences > Verify code after upload** setting. In Arduino IDE versions 1.6.8 and previous this property is set to true or false depending on the preferences setting which causes **Upload** with Arduino IDE 1.6.8 to generate AVRDUDE commands like:
```
avrdude -CE:\Stuff\misc\electronics\arduino\hardware\MiniCore\avr/avrdude.conf -v true -patmega328p -carduino -PCOM21 -b115200 -D -Uflash:w:C:\Users\per\AppData\Local\Temp\buildb7baad927be9bdd89a5f10c3d4ed06ef.tmp/sketch_sep28a.ino.hex:i 
```
AVRDUDE 6.0.1 is able to ignore the spurious true/false item in the command and successfully upload but when used with AVRDUDE 6.3.0 this causes upload to fail:
```
avrdude: no programmer has been specified on the command line or the config file
         Specify a programmer using the -c option and try again
```
This issue will occur if MiniCore is used with with Arduino IDE 1.6.8 or older and Arduino AVR Boards 1.6.12 or 1.6.14.

Setting a default empty value for the `upload.verify` property in platform.txt causes Arduino IDE 1.6.8 and older to generate an AVRDUDE command identical to that generated with Arduino AVR Boards 1.6.10 or older(meaning that, as previously, the preferences setting has no effect):
```
avrdude -CE:\Stuff\misc\electronics\arduino\hardware\MiniCore\avr/avrdude.conf -v -patmega328p -carduino -PCOM21 -b115200 -D -Uflash:w:C:\Users\per\AppData\Local\Temp\buildb7baad927be9bdd89a5f10c3d4ed06ef.tmp/sketch_sep28a.ino.hex:i 
```
Arduino IDE 1.6.9 and newer overrides the default value of `upload.verify`, therefore this change has no effect on the AVRDUDE command generated and verification is controlled by the preferences setting as usual.

Tested back to Arduino IDE 1.6.2, the oldest IDE version that supports Boards Manager updates.

Unfortunately a similar issue occurs with **Upload Using Programmer**. Due to the "platform.txt associated with the selected programmer is used for **Upload Using Programmer**" nightmare, setting a default value for `program.verify` in the MiniCore platform.txt will have no effect. The only possible solution would be to add MiniCore copies of all the programmers, which would use the MiniCore platform.txt for **Upload Using Programmer**, allowing the default value to be set for `program.verify` in the MiniCore platform.txt.

I have submitted a pull request to the Arduino IDE repository(https://github.com/arduino/Arduino/pull/5427) which will solve the **Upload Using Programmer** issue in future Arduino AVR Boards versions if merged but the issue will remain with Arduino AVR Boards 1.6.12 and 1.6.14.