### PR TITLE
Slight markdown change to allow the Board Manager URL to be selectable in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ Please check out the [Optiboot flasher example](https://github.com/MCUdude/MiniC
 This installation method requires Arduino IDE version 1.6.4 or greater.
 * Open the Arduino IDE.
 * Open the **File > Preferences** menu item.
-* Enter the following URL in **Additional Boards Manager URLs**: 
+* Enter the following URL in **Additional Boards Manager URLs**::
 
-        ```
-	https://mcudude.github.io/MiniCore/package_MCUdude_MiniCore_index.json
-	```
-    
+    ```
+    https://mcudude.github.io/MiniCore/package_MCUdude_MiniCore_index.json
+    ``` 
+
 * Open the **Tools > Board > Boards Manager...** menu item.
 * Wait for the platform indexes to finish downloading.
 * Scroll down until you see the **MiniCore** entry and click on it.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,11 @@ Please check out the [Optiboot flasher example](https://github.com/MCUdude/MiniC
 This installation method requires Arduino IDE version 1.6.4 or greater.
 * Open the Arduino IDE.
 * Open the **File > Preferences** menu item.
-* Enter the following URL in **Additional Boards Manager URLs**: `https://mcudude.github.io/MiniCore/package_MCUdude_MiniCore_index.json`
+* Enter the following URL in **Additional Boards Manager URLs**: 
+        ```
+	https://mcudude.github.io/MiniCore/package_MCUdude_MiniCore_index.json
+	```
+    
 * Open the **Tools > Board > Boards Manager...** menu item.
 * Wait for the platform indexes to finish downloading.
 * Scroll down until you see the **MiniCore** entry and click on it.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ This installation method requires Arduino IDE version 1.6.4 or greater.
 * Open the Arduino IDE.
 * Open the **File > Preferences** menu item.
 * Enter the following URL in **Additional Boards Manager URLs**: 
+
         ```
 	https://mcudude.github.io/MiniCore/package_MCUdude_MiniCore_index.json
 	```

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Please check out the [Optiboot flasher example](https://github.com/MCUdude/MiniC
 This installation method requires Arduino IDE version 1.6.4 or greater.
 * Open the Arduino IDE.
 * Open the **File > Preferences** menu item.
-* Enter the following URL in **Additional Boards Manager URLs**::
+* Enter the following URL in **Additional Boards Manager URLs**:
 
     ```
     https://mcudude.github.io/MiniCore/package_MCUdude_MiniCore_index.json


### PR DESCRIPTION
Before, you could not select the leading 'h', making it hard to cut and paste:
---
![image](https://user-images.githubusercontent.com/5520281/29480186-7f5aecb4-8444-11e7-956f-1de882f52bad.png)
---
