### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,263 @@
+# This file is used to configure the Travis CI tests of MiniCore
+
+# Although sudo is no longer required by arduino-ci-script since the 1.0.0 release, for some reason setting "sudo: false" causes the Travis CI build time to significantly increase so this setting is left as "sudo: required"
+sudo: required
+
+
+env:
+  global:
+    # The Arduino IDE will be installed at APPLICATION_FOLDER/arduino
+    - APPLICATION_FOLDER="${HOME}/arduino-ide"
+    - SKETCHBOOK_FOLDER="${HOME}/Arduino"
+
+    # README.md states that LTO should only be used with Arduino IDE 1.6.11 and newer
+    - OLDEST_IDE_VERSION_TO_TEST_WITH_LTO="1.6.11"
+
+    # The oldest version of the Arduino IDE that MiniCore's platform.txt is compatible with is 1.6.2 but that IDE version has a bug that interferes with other installations of the IDE.
+    # Arduino IDE 1.6.3-1.6.5-r5 on Linux don't seem to include the MiniCore bundled library files (this information copied from MegaCore so may not apply to MiniCore).
+    # Arduino IDE 1.6.6 has many function prototype generation failures.
+    # So testing is done with milestone Arduino IDE versions, 1.6.7 and newer.
+    - IDE_VERSIONS_BEFORE_OLDEST_IDE_VERSION_TO_TEST_WITH_LTO='"1.6.7" "1.6.9"'
+    - IDE_VERSIONS_FROM_OLDEST_IDE_VERSION_TO_TEST_WITH_LTO='"'"$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO"'" "1.6.13" "1.8.0" "1.8.5" "newest"'
+    - IDE_VERSION_LIST_LTO='('"$IDE_VERSIONS_FROM_OLDEST_IDE_VERSION_TO_TEST_WITH_LTO"')'
+    - IDE_VERSION_LIST_FULL='('"${IDE_VERSIONS_BEFORE_OLDEST_IDE_VERSION_TO_TEST_WITH_LTO} ${IDE_VERSIONS_FROM_OLDEST_IDE_VERSION_TO_TEST_WITH_LTO}"')'
+
+
+  matrix:
+    # Compile every example sketch for every library included with MiniCore for every MCU, every board option, every installed IDE version
+    # Each line in the matrix will be run as a separate job in the Travis CI build
+
+    # ATmega328
+    # variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:328:variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # LTO=Os_flto, clock=20MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:328:variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # variant=modelNonP, BOD=4v3, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:328:variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=1v8, clock=12MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:328:variant=modelP,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=disabled, clock=8MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:328:variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=8MHz_internal
+    # F_CPU of 8 MHz has already been fully tested and the BOD and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
+    - SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MiniCore:avr:328:variant=modelP,BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1MHz_internal
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:328:variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+
+    # ATmega168
+    # variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:168:variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # LTO=Os_flto, clock=20MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:168:variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # variant=modelNonP, BOD=4v3, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:168:variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=1v8, clock=12MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:168:variant=modelP,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=disabled, clock=8MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:168:variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=8MHz_internal
+    # F_CPU of 8 MHz has already been fully tested and the BOD and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
+    - SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MiniCore:avr:168:variant=modelP,BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1MHz_internal
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:168:variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+
+    # ATmega88
+    # variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:88:variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # LTO=Os_flto, clock=20MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:88:variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # variant=modelNonP, BOD=4v3, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:88:variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=1v8, clock=12MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:88:variant=modelP,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=disabled, clock=8MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:88:variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=8MHz_internal
+    # F_CPU of 8 MHz has already been fully tested and the BOD and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
+    - SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MiniCore:avr:88:variant=modelP,BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1MHz_internal
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:88:variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+
+    # ATmega48
+    # clock=8MHz_internal
+    # F_CPU of 8 MHz will be fully tested for clock=8MHz_external and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
+    - SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MiniCore:avr:48:variant=modelP,BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+
+    # Some library examples use more memory than this microcontroller provides so each library or sketch must be be done in a separate job
+    # AVR_examples
+    # variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:48:variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # LTO=Os_flto, clock=20MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:48:variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # variant=modelNonP, BOD=4v3, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:48:variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=1v8, clock=12MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:48:variant=modelP,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=disabled, clock=8MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:48:variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1MHz_internal
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:48:variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+
+    # Optiboot_flasher
+    # SerialReadWrite
+    # Fails to compile "Sketch too big" for ATmega48 so this library can't be tested
+
+    # SoftwareSerial
+    # Compilation of TwoPortRecieve example sketch with LTO=Os fails: "Sketch too big"
+    # LTO=Os
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial/examples/SoftwareSerialExample/SoftwareSerialExample.ino" BOARD_ID="MiniCore:avr:48:variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # variant=modelP, BOD=2v7, LTO=Os_flto, clock=16MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:48:variant=modelP,BOD=2v7,LTO=Os_flto,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # clock=20MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:48:variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # variant=modelNonP, BOD=4v3, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:48:variant=modelNonP,BOD=4v3,LTO=Os_flto,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # BOD=1v8, clock=12MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:48:variant=modelP,BOD=1v8,LTO=Os_flto,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # BOD=disabled, clock=8MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:48:variant=modelP,BOD=disabled,LTO=Os_flto,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # clock=1MHz_internal
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:48:variant=modelP,BOD=2v7,LTO=Os_flto,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+
+    # ATmega8
+    # Compilation of an example sketch for ATmega8 fails so each library/example must be done in separate jobs
+
+    # clock=8MHz_internal
+    # F_CPU of 8 MHz will be fully tested for clock=8MHz_external and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
+    - SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+
+    # AVR_examples
+    # Blink
+    # BOD=2v7, LTO=Os, clock=16MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Blink" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # LTO=Os_flto, clock=20MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Blink" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # BOD=4v0, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Blink" BOARD_ID="MiniCore:avr:8:BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=disabled, clock=12MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Blink" BOARD_ID="MiniCore:avr:8:BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=8MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Blink" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1MHz_internal
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Blink" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+
+    # Blink_using_Timer0
+    # Compilation of this example sketch for ATmeta8 fails: "error: 'OCR0' was not declared in this scope"
+
+    # Measure_period_length
+    # BOD=2v7, LTO=Os, clock=16MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Measure_period_length" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # LTO=Os_flto, clock=20MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Measure_period_length" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # BOD=4v0, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Measure_period_length" BOARD_ID="MiniCore:avr:8:BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=disabled, clock=12MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Measure_period_length" BOARD_ID="MiniCore:avr:8:BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=8MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Measure_period_length" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1MHz_internal
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Measure_period_length" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+
+    # Read_port_write_port
+    # BOD=2v7, LTO=Os, clock=16MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Read_port_write_port" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # LTO=Os_flto, clock=20MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Read_port_write_port" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # BOD=4v0, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Read_port_write_port" BOARD_ID="MiniCore:avr:8:BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=disabled, clock=12MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Read_port_write_port" BOARD_ID="MiniCore:avr:8:BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=8MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Read_port_write_port" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1MHz_internal
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Read_port_write_port" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+
+    # Watch_dog_timer
+    # BOD=2v7, LTO=Os, clock=16MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Watch_dog_timer" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # LTO=Os_flto, clock=20MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Watch_dog_timer" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # BOD=4v0, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Watch_dog_timer" BOARD_ID="MiniCore:avr:8:BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=disabled, clock=12MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Watch_dog_timer" BOARD_ID="MiniCore:avr:8:BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=8MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Watch_dog_timer" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1MHz_internal
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Watch_dog_timer" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+
+    # Optiboot_flasher
+    # BOD=2v7, LTO=Os, clock=16MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # LTO=Os_flto, clock=20MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # BOD=4v0, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:8:BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=disabled, clock=12MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:8:BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=8MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1MHz_internal
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+
+    # SoftwareSerial
+    # BOD=2v7, LTO=Os, clock=16MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # LTO=Os_flto, clock=20MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # BOD=4v0, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:8:BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=disabled, clock=12MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:8:BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=8MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1MHz_internal
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:8:BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+
+
+before_install:
+  # Install the script used to simplify use of Travis CI for testing Arduino projects
+  - source "${TRAVIS_BUILD_DIR}/avr/travis-ci/arduino-ci-script/arduino-ci-script.sh"
+
+  # These functions can be used to get verbose output for debugging the script
+  # set_script_verbosity can be set to values from 0 - 2 (verbosity off - maximum verbosity)
+  #- set_script_verbosity 1
+  # Setting set_verbose_output_during_compilation to true is the same as File > Preferences > Show verbose output during > compilation (check) in the Arduino IDE
+  #- set_verbose_output_during_compilation "true"
+
+  - set_application_folder "$APPLICATION_FOLDER"
+  - set_sketchbook_folder "$SKETCHBOOK_FOLDER"
+
+  # Check for board definition errors that don't affect compilation
+  - set_board_testing "true"
+
+  # Check for library issues that don't affect compilation
+  - set_library_testing "true"
+
+  # Install all IDE version required by the job
+  - install_ide "$IDE_VERSIONS"
+
+  # Install MiniCore from the repository
+  - install_package
+
+
+script:
+  # Verify every sketch in SKETCH_PATH using the environment variables set in the matrix
+  - build_sketch "$SKETCH_PATH" "$BOARD_ID" "$ALLOW_FAILURE" "all"
+
+
+after_script:
+  # Determine user name and repository name from TRAVIS_REPO_SLUG so the configuration will automatically adjust to forks
+  - USER_NAME="$(echo "$TRAVIS_REPO_SLUG" | cut -d'/' -f 1)"
+  - REPOSITORY_NAME="$(echo "$TRAVIS_REPO_SLUG" | cut -d'/' -f 2)"
+  # Commit a report of the job results to a folder named with the build number in the MiniCore branch of the CI-reports repository
+  - publish_report_to_repository "$REPORT_GITHUB_TOKEN" "https://github.com/${USER_NAME}/CI-reports.git" "$REPOSITORY_NAME" "build_$(printf "%05d\n" "${TRAVIS_BUILD_NUMBER}")" "false"
+
+  # Print a tab separated report of all sketch verification results to the log
+  - display_report
+
+
+notifications:
+  email:
+    on_success: never
+    on_failure: always

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MiniCore
+[![Build Status](https://travis-ci.org/MCUdude/MiniCore.svg?branch=master)](https://travis-ci.org/MCUdude/MiniCore)
 An Arduino core for the ATmega8, ATmega48, ATmega88, ATmega168 and ATmega328, all running a [custom version of Optiboot for increased functionality](#write-to-own-flash). This core requires at least Arduino IDE v1.6.2, where v1.6.5+ is recommended. <br/>
 **This core gives you two extra IO pins if you're using the internal oscillator!** PB6 and PB7 is mapped to [Arduino pin 20 and 21](#pinout).<br/>
 If you're into "generic" AVR programming, I'm happy to tell you that all relevant keywords are being highlighted by the IDE through a separate keywords file. Make sure to test the [example files](https://github.com/MCUdude/MiniCore/tree/master/avr/libraries/AVR_examples/examples) (File > Examples > AVR C code examples). Try writing a register name, <i>DDRB</i> for instance, and see for yourself!

--- a/avr/travis-ci/arduino-ci-script/.travis.yml
+++ b/avr/travis-ci/arduino-ci-script/.travis.yml
@@ -1,0 +1,188 @@
+# This file is used to test the script with Travis CI
+
+# Although sudo is no longer required by arduino-ci-script since the 1.0.0 release, for some reason setting "sudo: false" causes the Travis CI build time to significantly increase so this setting is left as "sudo: required"
+sudo: required
+
+
+env:
+  global:
+    # The Arduino IDE will be installed at APPLICATION_FOLDER/arduino
+    - APPLICATION_FOLDER="${HOME}/arduino-ide"
+    - SKETCHBOOK_FOLDER="${HOME}/arduino-sketchbook"
+
+  matrix:
+    # Test install_ide with no argument (using full version list). This would cause the Travis CI build to take much longer so I have it disabled
+    # - INSTALL_IDE_START_VERSION=""
+    # Test install_ide using full version list
+    - INSTALL_IDE_START_VERSION="all" VERBOSITY_LEVEL=0 VERBOSE_COMPILATION="false"
+    # Test install_ide using custom version list. Test the use of the special version names "oldest" and "newest" in a version list. Test use of "hourly" version name.
+    - INSTALL_IDE_START_VERSION='("oldest" "1.8.1" "1.8.2" "newest" "hourly")' VERBOSITY_LEVEL=1 VERBOSE_COMPILATION="true"
+    # Allowed to fail
+    # Test install_ide using single version
+    # test the failure behavior of install_package when a Boards Manager installation is attempted using an IDE version that doesn't support it.
+    - INSTALL_IDE_START_VERSION="1.6.3" VERBOSITY_LEVEL=2 VERBOSE_COMPILATION="false"
+    # Test install_ide using version range. Test the use of the special version names "oldest" and "newest" in a version range.
+    - INSTALL_IDE_START_VERSION="oldest" INSTALL_IDE_END_VERSION="newest" VERBOSITY_LEVEL=0 VERBOSE_COMPILATION="false"
+
+
+matrix:
+  allow_failures:
+    # The expected behavior is failure because 1.6.3 doesn't support boards manager installation.
+    - env: INSTALL_IDE_START_VERSION="1.6.3" VERBOSITY_LEVEL=2 VERBOSE_COMPILATION="false"
+
+
+addons:
+  apt:
+    sources:
+    - debian-sid
+    packages:
+    - shellcheck
+
+
+before_install:
+  # Check for issues in the script
+  - bash -c 'shopt -s globstar; shellcheck arduino-ci-script.sh'
+
+  # Check for trailing whitespace in all files in the repository
+  - "if grep --line-number --recursive --exclude-dir=.git '[[:blank:]]$' .; then echo 'Trailing whitespace found.'; false; fi"
+  # Check for tabs in all files in the repository
+  - "if grep --line-number --recursive --exclude-dir=.git $'\t' .; then echo 'Tab found.'; false; fi"
+  # Check if all files in the repository end in a newline (https://stackoverflow.com/a/25686825)
+  - find . -path ./.git -prune -o -type f -print0 | xargs -0 -L1 bash -c 'if test "$(tail --bytes=1 "$0")"; then echo "No new line at end of $0"; false; fi'
+
+  - source "${TRAVIS_BUILD_DIR}/arduino-ci-script.sh"
+
+  - set_script_verbosity "$VERBOSITY_LEVEL"
+
+  - set_application_folder "$APPLICATION_FOLDER"
+  - set_sketchbook_folder "$SKETCHBOOK_FOLDER"
+
+  # Check for board definition errors that don't affect compilation
+  - set_board_testing "true"
+
+  # Check for library issues that don't affect compilation
+  - set_library_testing "true"
+
+  - install_ide "$INSTALL_IDE_START_VERSION" "$INSTALL_IDE_END_VERSION"
+
+  # Install hardware packages
+  # Test package install from this repository (can't do this because the repository isn't a hardware package)
+  # - install_package
+  # Test manual package install from compressed file download
+  - install_package "https://github.com/SpenceKonde/ATTinyCore/archive/master.zip"
+  # Test manual package install from Git repository clone
+  - install_package "https://github.com/MCUdude/MightyCore.git"
+  # Test manual package install from Git repository clone
+  - install_package "https://github.com/JChristensen/mighty-1284p.git" "v1.6.3"
+
+  # Test library installation from repository (can't do this because there is no library in this repository)
+  # - install_library
+  # Test library install from .zip file. A non-GitHub library download must be used because GitHub appends -{branch name} or -{release version} to the .zip downloads and having a library folder installed whos name contains "-" causes arduino 1.5.6 or older to hang.
+  - install_library "https://bitbucket.org/teckel12/arduino-new-ping/downloads/NewPing_v1.8.zip"
+  # Test library install from .zip file with rename. If the rename doesn't work then any job verifying with Arduino IDE 1.5.6 or older will hang because GitHub changes the folder name to MPU9250-master, which is not a valid folder name on those IDE versions.
+  - install_library "https://github.com/brianc118/MPU9250/archive/master.zip" "MPU9250"
+  # Test library install from .zip file/folder that has a dot in the name
+  - install_library "https://github.com/arduino-libraries/CapacitiveSensor/archive/0.5.1.zip"
+  # Test library install from git repo
+  - install_library "https://github.com/sfrwmaker/WirelessOregonV2.git"
+  # Test library install from git repo with branch
+  - install_library "https://github.com/sde1000/NanodeUNIO.git" "master"
+  # Test library install from git repo with rename
+  - install_library "https://github.com/mikaelpatel/Arduino-Shell.git" "" "ArduinoShell"
+  # Test library install from git repo with branch and rename
+  - install_library "https://github.com/Avamander/max7456.git" "master" "max_7456"
+  # Test set_verbose_output_during_compilation.
+  - set_verbose_output_during_compilation "$VERBOSE_COMPILATION"
+
+  # Boards Manager and Library Manager tests are done as late as possible to allow job 3 to do more thorough testing of script verbosity level 2 before the job fails
+
+  # Test Boards Manager package install without URL. Test error handling of attempting to do a Boards Manager installation when the newest installed IDE version doesn't support it (should print a helpful error message and fail instead of hanging).
+  - install_package "arduino:sam"
+  # Test Boards Manager package install with URL
+  - install_package "MiniCore:avr" "https://mcudude.github.io/MiniCore/package_MCUdude_MiniCore_index.json"
+
+  # Test library install from Library Manager
+  - install_library "Pushetta:1.0.1"
+
+
+script:
+  # Verify sketches:
+  # build_sketch arguments: sketch name, fqbn, IDE version, allow failure
+  # IDE version: Use "all" for IDE version argument to verify sketch with all versions of the Arduino IDE, use "newest" for IDE version argument to verify sketch with the newest version of the Arduino IDE
+
+  # Installed package tests:
+  # Test board from hardware package installed via Boards Manager without URL
+  # Test build_sketch with "newest" special version name
+  - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" "arduino:sam:arduino_due_x_dbg" "false" "newest"
+  # Test board from hardware package installed with Boards Manager URL
+  # Test build_sketch with specific IDE version
+  - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" "MiniCore:avr:328:variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" "false" "1.8.1"
+  # Test board from hardware package manually installed from compressed file download
+  # Test build_sketch with an IDE version list
+  - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" "ATTinyCore-master:avr:attinyx5:LTO=disable,TimerClockSource=default,chip=85,clock=8internal,bod=disable" "false" '("1.8.1" "1.8.2")'
+  # Test board from hardware package manually installed by cloning Git repository
+  # Test build_sketch with an IDE version range
+  - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" "MightyCore:avr:1284:pinout=standard,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" "false" "1.8.1" "1.8.2"
+  # Test board from hardware package manually installed by cloning Git repository with non-default branch
+  - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" "mighty-1284p:avr:avr_developers" "false" "newest"
+
+  # Installed library tests:
+  # Test build_sketch without absolute path
+  # Test library installed from .zip with rename
+  - cd "${SKETCHBOOK_FOLDER}/libraries/MPU9250/examples/MPU9250/"
+  - build_sketch "MPU9250.ino" "arduino:avr:uno" "false" "newest"
+  # Test library installed from .zip with dot in the folder name
+  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/CapacitiveSensor-0.5.1/examples/CapacitiveSensorSketch/CapacitiveSensorSketch.pde" "arduino:avr:uno" "false" "newest"
+  # Test library installed from .zip
+  # Test build_sketch with "all" IDE version name
+  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/NewPing/examples/NewPingExample/NewPingExample.pde" "arduino:avr:uno" "false" "all"
+  # Test library installed from .git
+  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/WirelessOregonV2/examples/OregonReceiver/OregonReceiver.ino" "arduino:avr:uno" "false" "newest"
+  # Test library installed from .git with branch
+  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/NanodeUNIO/examples/NanodeUNIO_test/NanodeUNIO_test.pde" "arduino:avr:uno" "false" "newest"
+  # Test library installed from .git with rename
+  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/ArduinoShell/examples/ShellBlink/ShellBlink.ino" "arduino:avr:uno" "false" "newest"
+  # Test library installed from .git with branch and rename
+  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/max_7456/examples/HelloWorld/HelloWorld.ino" "arduino:avr:uno" "false" "newest"
+  # Test library installed from Library Manager
+  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/Pushetta/examples/simple_notification/simple_notification.ino" "arduino:avr:uno" "false" "newest"
+
+  # build_sketch with version argument tests
+  # Test build_sketch with no IDE version argument (should use all installed IDE versions)
+  - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" "arduino:avr:uno" "false"
+  # Test build_sketch with "oldest" IDE version name
+  - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" "arduino:avr:uno" "false" "oldest"
+  # Test build_sketch allowed to fail (this will fail because WirelessOregonV2 is AVR specific)
+  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/WirelessOregonV2/examples/OregonReceiver/OregonReceiver.ino" "arduino:sam:arduino_due_x_dbg" "true" "newest"
+
+  # build_sketch with folder argument tests:
+  # Test build_sketch with folder argument with specific IDE version
+  - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics" "arduino:avr:uno" "false" "1.8.1"
+  # Test build_sketch with folder argument with "oldest" IDE version name
+  - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics" "arduino:avr:uno" "false" "oldest"
+  # Test build_sketch with folder argument with "newest" IDE version name
+  - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics" "arduino:avr:uno" "false" "newest"
+  # Test build_sketch with folder argument with "all" IDE version name
+  - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics" "arduino:avr:uno" "false" "all"
+  # Test build_sketch with folder argument with no IDE version specified (should use all installed IDE versions)
+  - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics" "arduino:avr:uno" "false"
+  # Test build_sketch with folder argument with an IDE version list
+  - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics" "arduino:avr:uno" "false" '("1.8.1" "1.8.2")'
+  # Test build_sketch with folder argument with an IDE version range
+  - build_sketch "${APPLICATION_FOLDER}/arduino/examples/01.Basics" "arduino:avr:uno" "false" "1.8.1" "1.8.2"
+  # Test build_sketch with folder argument required to fail (this will fail because WirelessOregonV2 is AVR specific)
+  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/WirelessOregonV2/examples" "arduino:sam:arduino_due_x_dbg" "require" "newest"
+
+  - publish_report_to_gist "$REPORT_GITHUB_TOKEN" "$REPORT_GIST_URL" "true"
+
+  - USER_NAME="$(echo "$TRAVIS_REPO_SLUG" | cut -d'/' -f 1)"
+  - REPOSITORY_NAME="$(echo "$TRAVIS_REPO_SLUG" | cut -d'/' -f 2)"
+  - publish_report_to_repository "$REPORT_GITHUB_TOKEN" "https://github.com/${USER_NAME}/CI-reports.git" "$REPOSITORY_NAME" "build_$(printf "%05d\n" "${TRAVIS_BUILD_NUMBER}")" "true"
+
+  - display_report
+
+
+notifications:
+  email:
+    on_success: always
+    on_failure: always

--- a/avr/travis-ci/arduino-ci-script/CONTRIBUTING.md
+++ b/avr/travis-ci/arduino-ci-script/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contribution Rules
+Thanks for your interest in contributing to this free open source project! Please take the time to read and follow these rules before submitting an issue report or pull request.
+
+## Issues
+- Do you need help using this project? Support requests should be made to the appropriate section of the [Arduino forum](http://forum.arduino.cc) rather than an issue report. Feel free to [send me a PM](http://forum.arduino.cc/index.php?action=pm;sa=send;u=224903) with a link to your forum thread. **Support will not be provided via PM**, I prefer to help you publicly so that others with the same question may benefit from the information. **Issue reports are to be used to report bugs or make feature requests only.**
+- Before submitting a bug report test using the [latest version of the project](https://github.com/per1234/arduino-ci-script/archive/master.zip) to be sure it hasn't already been fixed. **Don't report issues that only occur with old versions of the project.**
+- Search [existing pull requests and issues](https://github.com/per1234/arduino-ci-script/issues?q=) to be sure it hasn't already been reported. **Do not submit duplicate issue reports.** If you have additional information to provide about the issue then please comment on that issue.
+- Open an issue at https://github.com/per1234/arduino-ci-script/issues/new.
+- Describe the issue and what behavior you were expecting. Post complete error messages using [markdown code fencing](https://guides.github.com/features/mastering-markdown/#examples).
+- Provide a full set of steps necessary to reproduce the issue. Demonstration code should be complete, correct and simplified to the minimum amount of code necessary to reproduce the issue. Please use [markdown code fencing](https://guides.github.com/features/mastering-markdown/#examples) when posting code.
+- Be responsive. I may need you to provide more information, please respond as soon as possible.
+- If you find a solution to your problem update your issue report with an explanation of how you were able to fix it and close the issue.
+
+## Pull Requests
+- Search [existing pull requests and issues](https://github.com/per1234/arduino-ci-script/pulls?q=) to make sure the change hasn't already been proposed.
+- Comment your code. The focus of Arduino is learning so it's best to be a bit more thorough about documenting code.
+- Follow the formatting conventions used throughout the rest of the project. Remove all trailing whitespace.
+- If appropriate, add or update tests in the [.travis.yml file](https://github.com/per1234/arduino-ci-script/blob/master/.travis.yml).
+- Update the [documentation](https://github.com/per1234/arduino-ci-script/blob/master/README.md) if your changes require it. This should be done in the same commit as the change.
+- **All commits must be atomic**. This means that the commit completely accomplishes a single task. Each commit should result in fully functional code. Multiple tasks should not be combined in a single commit. For more information please read http://www.freshconsulting.com/atomic-commits.
+- Commit messages: Use the [imperative mood](http://chris.beams.io/posts/git-commit/#imperative) in the commit title. Completely explain the purpose of the commit. Please read http://chris.beams.io/posts/git-commit for more tips on writing good commit messages.
+- Each pull request should address a single bug fix or enhancement, this may consist of multiple commits. If you have multiple, unrelated fixes or enhancements to contribute, then do each in a separate pull request.
+- Open a pull request at https://github.com/per1234/arduino-ci-script/compare.
+- If your pull request fixes an issue in the issue tracker, use the [closes/fixes/resolves syntax](https://help.github.com/articles/closing-issues-via-commit-messages) in the body to denote this.

--- a/avr/travis-ci/arduino-ci-script/ISSUE_TEMPLATE.md
+++ b/avr/travis-ci/arduino-ci-script/ISSUE_TEMPLATE.md
@@ -1,0 +1,1 @@
+Read the Issues section of the Contribution Rules at the "guidelines for contributing" link above before submitting an issue report.

--- a/avr/travis-ci/arduino-ci-script/LICENSE
+++ b/avr/travis-ci/arduino-ci-script/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2017
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/avr/travis-ci/arduino-ci-script/PULL_REQUEST_TEMPLATE.md
+++ b/avr/travis-ci/arduino-ci-script/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,1 @@
+Read the Pull Requests section of the Contribution Rules at the "guidelines for contributing" link above before submitting a pull request.

--- a/avr/travis-ci/arduino-ci-script/README.md
+++ b/avr/travis-ci/arduino-ci-script/README.md
@@ -1,0 +1,213 @@
+arduino-ci-script
+==========
+
+Bash script for continuous integration of [Arduino](http://www.arduino.cc/) projects. I'm using this centrally managed script for multiple repositories to make updates easy. I'm using this with [Travis CI](http://travis-ci.org/) but it could be easily adapted to other purposes.
+
+[![Build Status](https://travis-ci.org/per1234/arduino-ci-script.svg?branch=master)](https://travis-ci.org/per1234/arduino-ci-script)
+
+#### Installation
+- You can download a .zip of all the files from https://github.com/per1234/arduino-ci-script/archive/master.zip
+- Include the script in your project by adding the following line:
+```bash
+  - source arduino-ci-script.sh
+```
+- It's possible to leave the script hosted at this repository.
+```bash
+  - source <(curl -SLs https://raw.githubusercontent.com/per1234/arduino-ci-script/master/arduino-ci-script.sh)
+```
+- The above doesn't allow you control over the version and would not be a good idea for security reasons if you use the functions that take a GitHub token argument. You could use the script at a specific point in the commit history with something like this:
+```bash
+  - git clone https://github.com/per1234/arduino-ci-script.git "${HOME}/arduino-ci-script"
+  - cd "${HOME}/arduino-ci-script"
+  - git checkout 0355314d45970cd33e52ebba9967646a063ea9eb
+  - source "${HOME}/arduino-ci-script/arduino-ci-script.sh"
+```
+
+
+#### Usage
+See https://github.com/per1234/WatchdogLog/blob/master/.travis.yml for an example of the script in use. Please configure your continuous integration system to make the minimum number of downloads and sketch verifications necessary to effectively test your code. This will prevent wasting Arduino and Travis CI's bandwidth while making the builds run fast.
+##### `set_script_verbosity SCRIPT_VERBOSITY_LEVEL`
+Control the level of verbosity of the script's output in the Travis CI log. Verbose output can be helpful for debugging but in normal usage it makes the log hard to read and may cause the log to exceed Travis CI's maximum log size of 4 MB, which causes the job to be terminated. The default verbosity level is `0`.
+- Parameter: **SCRIPT_VERBOSITY_LEVEL** - `0`, `1` or `2` (least to most verbosity).
+
+##### `set_application_folder APPLICATION_FOLDER`
+- Parameter: **APPLICATION_FOLDER** - The folder to install the Arduino IDE to. This should be set to `/usr/local/share` or a subfolder of that location. The folder will be created if it doesn't already exist. The Arduino IDE will be installed in the `arduino` subfolder.
+
+##### `set_sketchbook_folder SKETCHBOOK_FOLDER`
+- Parameter: **SKETCHBOOK_FOLDER** - The folder to be set as the Arduino IDE's sketchbook folder. The folder will be created if it doesn't already exist. Libraries installed via `install_library` will be installed to the `libraries` subfolder. Non-Boards Manager hardware packages installed via `install_package` will be installed to the `hardware` subfolder. This setting is only supported by Arduino IDE 1.5.6 and newer.
+
+##### `set_board_testing BOARD_TESTING`
+Turn on/off checking for errors with the board definition that don't affect sketch verification such as missing bootloader file. If this is turned on and an error is detected the build will be failed. This feature is off by default.
+- Parameter: **BOARD_TESTING** - `true`/`false`
+
+##### `set_library_testing LIBRARY_TESTING`
+Turn on/off checking for errors with libraries that don't affect sketch verification such as missing or invalid items in the library.properties file. If this is turned on and an error is detected the build will be failed. This feature is off by default.
+- Parameter: **LIBRARY_TESTING** - `true`/`false`
+
+##### Special version names:
+  - `all`: Refers to all versions of the Arduino IDE (including the hourly build). In the context of `install_ide` this means all IDE versions listed in the script (those that support the command line interface, 1.5.2 and newer). In the context of all other functions this means all IDE versions that were installed via `install_ide`.
+  - `oldest`: The oldest release version of the Arduino IDE. In the context of `install_ide` this is the oldest of the IDE versions listed in the script (1.5.2, the first version to have a command line interface). In the context of build_sketch this means the oldest IDE version that was installed via `install_ide`.
+  - `newest`: Refers to the newest release version of the Arduino IDE (not including the hourly build unless hourly is the only version on the list). In the context of `install_ide` this means the newest IDE version listed in the script. In the context of all other functions this means the newest IDE version that was installed via `install_ide`.
+  - `hourly`: The hourly build of the Arduino IDE. Note that this IDE version is intended for beta testing only.
+
+##### `install_ide [IDEversionList]`
+Install a list of version(s) of the Arduino IDE.
+- Parameter(optional): **IDEversionList** - A list of the versions of the Arduino IDE you want installed, in order from oldest to newest. e.g. `'("1.6.5-r5" "1.6.9" "1.8.2")'`. If no arguments are supplied all IDE versions will be installed. I have defined all versions of the Arduino IDE that have a command line interface in the script for the sake of being complete but I really don't see much reason for testing with the 1.5.x versions of the Arduino IDE. Please only install the IDE versions you actually need for your test to avoid wasting Arduino's bandwidth. This will also result in the builds running faster.
+
+##### `install_ide startIDEversion [endIDEversion]`
+Install a range of version(s) of the Arduino IDE.
+- Parameter: **startIDEversion** - The oldest version of the Arduino IDE to install.
+- Parameter(optional): **endIDEversion** - The newest version of the Arduino IDE to install. If this argument is omitted then only startIDEversion will be installed.
+
+##### `install_package`
+"Manually" install the hardware package from the current repository. Packages are installed to `$SKETCHBOOK_FOLDER/hardware. Assumes the hardware package is located in the root of the download or repository and has the correct folder structure.
+
+##### `install_package packageURL`
+"Manually" install a hardware package downloaded as a compressed file. Packages are installed to `$SKETCHBOOK_FOLDER/hardware. Assumes the hardware package is located in the root of the file and has the correct folder structure.
+- Parameter: **packageURL** - The URL of the hardware package download. The protocol component of the URL (e.g. `http://`, `https://`) is required.
+
+##### `install_package packageURL [branchName]`
+"Manually" install a hardware package. Packages are installed to `$SKETCHBOOK_FOLDER/hardware. Assumes the hardware package is located in the root of the repository and has the correct folder structure.
+- Parameter: **packageURL** - The URL of the Git repository. The protocol component of the URL (e.g. `http://`, `https://`) is required.
+- Parameter(optional): **branchName** - Branch of the repository to install. If this argument is not specified or is left blank the default branch will be used.
+
+##### `install_package packageID [packageURL]`
+Install a hardware package using the Arduino IDE (Boards Manager). Only the **Arduino AVR Boards** package is included with the Arduino IDE installation. Packages are installed to `$HOME/.arduino15/packages. You must call `install_ide` before this function. This feature is only available with Arduino IDE 1.6.4 and newer.
+- Parameter: **packageID** - `package name:platform architecture[:version]`. If `version` is omitted the most recent version will be installed. e.g. `arduino:samd` will install the most recent version of **Arduino SAM Boards**.
+- Parameter(optional): **packageURL** - The URL of the Boards Manager JSON file for 3rd party hardware packages. This can be omitted for hardware packages that are included in the official Arduino JSON file (e.g. Arduino SAM Boards, Arduino SAMD Boards, Intel Curie Boards).
+
+##### `install_library`
+Install the library from the current repository. Assumes the library is in the root of the repository. The library is installed to the `libraries` subfolder of the sketchbook folder.
+
+##### `install_library libraryName`
+Install a library that is listed in the Arduino Library Manager index. The library is installed to the `libraries` subfolder of the sketchbook folder. You must call `install_ide` before this function. This feature is only available with Arduino IDE 1.6.4 and newer installed.
+- Parameter: **libraryName** - The name of the library to install. You can specify a version separated from the name by a colon, e.g. "LiquidCrystal I2C:1.1.2". If no version is specified the most recent version will be installed. You can also specify comma-separated lists of library names.
+
+##### `install_library libraryURL [newFolderName]`
+Download a library in a compressed file from a URL. The library is installed to the `libraries` subfolder of the sketchbook folder.
+- Parameter: **libraryURL** - The URL of the library download or library name in the Arduino Library Manager. The protocol component of the URL (e.g. `http://`, `https://`) is required. This can be any compressed file format. Assumes the library is located in the root of the file.
+- Parameter(optional): **newFolderName** - Folder name to rename the installed library folder to. This can be useful if the default folder name of the downloaded file is problematic. The Arduino IDE gives include file preference when the filename matches the library folder name. GitHub's "Download ZIP" file is given the folder name {repository name}-{branch name}. Library folder names that contain `-` or `.` are not compatible with Arduino IDE 1.5.6 and older, arduino will hang if it's started with a library using an invalid folder name installed.
+
+##### `install_library libraryURL [branchName [newFolderName]]`
+Install a library by cloning a Git repository). The library is installed to the `libraries` subfolder of the sketchbook folder.
+- Parameter: **libraryURL** - The URL of the library download or library name in the Arduino Library Manager. The protocol component of the URL (e.g. `http://`, `https://`) is required. Assumes the library is located in the root of the repository.
+- Parameter(optional): **branchName** - Branch of the repository to install. If this argument is not specified or is left blank the default branch will be used.
+- Parameter(optional): **newFolderName** - Folder name to rename the installed library folder to. This can be useful if the default folder name of the downloaded file is problematic. The Arduino IDE gives include file preference when the filename matches the library folder name. Library folder names that contain `-` or `.` are not compatible with Arduino IDE 1.5.6 and older, arduino will hang if it's started with a library using an invalid folder name installed. If the `newFolderName` argument is specified the `branchName` argument must also be specified. If you don't want to specify a branch then use `""` for the `branchName` argument.
+
+##### `set_verbose_output_during_compilation verboseOutputDuringCompilation`
+Turn on/off arduino verbose output during compilation. This will show all the commands arduino runs during the process rather than just the compiler output. This is usually not very useful output and only clutters up the log. This feature is off by default.
+- Parameter: **verboseOutputDuringCompilation** - `true`/`false`
+
+##### `build_sketch sketchPath boardID allowFail IDEversion`
+##### `build_sketch sketchPath boardID allowFail [IDEversionList]`
+##### `build_sketch sketchPath boardID allowFail startIDEversion endIDEversion`
+Pass some parameters from .travis.yml to the script. `build_sketch` will echo the arduino exit status to the log, which is documented at https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc#exit-status.
+- Parameter: **sketchPath** - Path to a sketch or folder containing sketches. If a folder is specified it will be recursively searched and all sketches will be verified.
+- Parameter: **boardID** - `package:arch:board[:parameters]` ID of the board to be compiled for. e.g. `arduino:avr:uno`. Board-specific parameters are only supported by Arduino IDE 1.5.5 and newer.
+- Parameter: **allowFail** - `true`, `require`, or `false`. Allow the verification to fail without causing the CI build to fail. `require` will cause the build to fail if the sketch verification doesn't fail.
+- Parameter: **IDEversion** - A single version of the Arduino IDE to use to verify the sketch.
+- Parameter(optional): **IDEversionList** - A list of versions of the Arduino IDE to use to verify the sketch. e.g. `'("1.6.5-r5" "1.6.9" "1.8.2")'`. If no version list is provided all installed IDE versions will be used.
+- Parameter: **startIDEversion** - The start (inclusive) of a range of versions of the Arduino IDE to use to verify the sketch.
+- Parameter: **endIDEversion** - The end (inclusive) of a range of versions of the Arduino IDE to use to verify the sketch.
+
+##### `display_report`
+Echo a tab separated report of all verification results to the log. The report is located in `${HOME}/arduino-ci-script_report`. Note that Travis CI runs each build of the job in a separate virtual machine so if you have multiple jobs you will have multiple reports. The only way I have found to generate a single report for all tests is to run them as a single job. This means not setting multiple matrix environment variables in the `env` array. See https://docs.travis-ci.com/user/environment-variables. The report consists of:
+- Build timestamp
+- Build - The Travis CI build number.
+- Job - Travis CI job number
+- Job URL - The URL of the Travis CI job log.
+- Build Trigger - The cause of this Travis CI build. Values are `push`, `pull_request`, `api`, `cron`.
+- Allow Job Failure - Whether the Travis CI configuration was set to allow the failure of this job without failing the build.
+- PR# - Pull request number (if build was triggered by a pull request).
+- Branch - The branch of the repository that was built.
+- Commit - Commit hash of the build.
+- Commit range - The range of commits that were included in the push or pull request.
+- Commit Message - First line of the commit message
+- Sketch filename
+- Board ID
+- IDE version
+- Program Storage (bytes) - Program storage usage of the compiled sketch.
+- Dynamic Memory (bytes) - Dynamic memory usage by global variables in the compiled sketch (not available for some boards).
+- \# Warnings - Number of warnings reported by the compiler during the sketch compilation.
+- Allow Failure - Whether the sketch verification was allowed to fail (set by the `allowFail` argument of `build_sketch`).
+- Exit Status - Exit status returned by arduino after the sketch verification.
+- \# Board Issues - The number of board issues detected.
+- Board Issue - Short description of the last board issue detected.
+- \# Library Issues - The number of library issues detected. Library issues are things that cause warnings in the sketch verification output from the IDE, rather than the compiler.
+- Library Issue - Short description of the last library issue detected.
+
+##### `publish_report_to_repository REPORT_GITHUB_TOKEN repositoryURL reportBranch reportFolder doLinkComment`
+Add the report to a repository. See the [instructions for publishing job reports](publishing-job-reports) for details.
+- Parameter: **REPORT_GITHUB_TOKEN** - The hidden or encrypted environment variable containing the GitHub personal access token.
+- Parameter: **repositoryURL** - The .git URL of the repository to publish the report to. This URL can be found by clicking the "Clone or download" button on the home page of the repository. The repository must already exist.
+- Parameter: **reportBranch** - The branch to publish the report to. The branch must already exist.
+- Parameter: **reportFolder** - The the folder to publish the report to. The folder will be created if it doesn't exist.
+- Parameter: **doLinkComment** - `true` or `false` Whether to comment on the commit with a link to the report.
+
+##### `publish_report_to_gist REPORT_GITHUB_TOKEN REPORT_GIST_URL doLinkComment`
+Add the report to the report gist. See the [instructions for publishing job reports](publishing-job-reports) for details.
+- Parameter: **REPORT_GITHUB_TOKEN** - The hidden or encrypted environment variable containing the GitHub personal access token.
+- Parameter: **REPORT_GIST_URL** - The URL of the report gist.
+- Parameter: **doLinkComment** - `true` or `false` Whether to comment on the commit with a link to the report.
+
+
+#### Publishing job reports
+The script offers the option of publishing the job result reports to a repository or GitHub [gist](https://gist.github.com/) by using the `publish_report_to_repository` or `publish_report_to_gist` functions. This makes it easier to view the reports or to import them into a spreadsheet program. You also have the option of having the link to the reports automatically added in a comment to the commit being tested. This requires some configuration, which is described in the instructions below.
+
+NOTE: For security reasons reports for builds of pull requests from a fork of the repository can not be published. If the owner of that fork wants to publish reports they can create a GitHub token (and gist if using `publish_report_to_gist`) and configure the Travis CI settings for their fork of the repository following these instructions.
+##### Creating a GitHub personal access token
+This is required for either publishing option.
+1. Sign in to your GitHub account.
+2. Click your avatar at the top right corner of GitHub > **Settings** > **Personal access tokens** > **Generate new token**.
+3. Check the appropriate permissions for the token:
+  1. If using `publish_report_to_gist` check **gist**.
+  2. If using `publish_report_to_repository` or setting the `doLinkComment` argument of `publish_report_to_gist` check **public_repo** (for public repositories only) or **repo** (for private and public repositories).
+5. Click the **Generate token** button.
+6. When the generated token is displayed click the clipboard icon next to it to copy the token.
+7. Open the settings page for your repository on the Travis CI website.
+8. In the **Environment Variables** section enter `REPORT_GITHUB_TOKEN` in the **Name** field and the token in the **Value** field. Make sure the **Display value in build log** switch is in the off position.
+9. Click the **Add** button.
+
+An alternative to using a Travis CI hidden environment variable as described above is to define the GitHub personal access token as an encrypted environment variable: https://docs.travis-ci.com/user/environment-variables/#Encrypting-environment-variables.
+##### Creating a gist
+This is required for use of the `publish_report_to_gist` function.
+1. Open https://gist.github.com/
+2. Sign in to your GitHub account.
+3. Type an appropriate name in the **Filename including extension...** field. Gists sort files alphabetically so the filename should be something that will sort before the report filenames, which start at travis_ci_job_report_1.1.tsv.
+4. Add some text to the file contents box.
+5. Click **Create secret gist** if you don't want the gist to be discoverable (it can still be read by anyone who knows the URL), or **Create public gist** to make it discoverable.
+6. Copy the URL of the gist.
+7. Open the settings page for your repository on the Travis CI website.
+8. In the **Environment Variables** section enter `REPORT_GIST_URL` in the **Name** field and the URL of the gist in the **Value** field. You can turn the **Display value in build log** switch to the on position. The gist URL is not secret and this will provide more information in the log.
+9. Click the **Add** button.
+
+
+#### Troubleshooting
+##### Script hangs after an arduino command
+The Arduino IDE will usually try to start the GUI whenever there is an error in the command. Since the Travis CI build environment does not support this it will just hang for ten minutes until Travis CI automatically cancels the job. This means you get no useful information on the cause of the problem.
+##### Verbose output
+Verbose output results in a harder to read log so you should leave it off or minimized when possible. Note that turning on verbose output for a large build may cause the log to exceed 4 MB, which causes Travis CI to terminate the job.
+- Verbose script output - Add or uncomment the following lines in your `.travis.yml` file to get more information for troubleshooting.
+  - Print shell input lines as they are read:
+    - `- set_verbose_script_output "true"`
+  - Print a trace of simple commands, for commands, case commands, select commands, and arithmetic for commands and their arguments or associated word lists after they are expanded and before they are executed. The value of the PS4 variable is expanded and the resultant value is printed before the command and its expanded arguments.
+    - `- set_more_verbose_script_output "true"`
+- Verbose output for Travis CI and script - Add one or both of the following lines to your `.travis.yml` file to get more information for troubleshooting of both the Travis CI build process and the script. Do not turn on verbosity by passing `true` to `set_verbose_script_output` or `set_more_verbose_script_output` when you have these lines in your `.travis.yml` file.
+  - Print shell input lines as they are read:
+    - `- set -o verbose`
+  - Print a trace of simple commands, for commands, case commands, select commands, and arithmetic for commands and their arguments or associated word lists after they are expanded and before they are executed. The value of the PS4 variable is expanded and the resultant value is printed before the command and its expanded arguments.
+    - `- set -o xtrace`
+- Verbose output during compilation - Add the following line to your `.travis.yml` file to get verbose output from arduino of the commands used in the sketch building process:
+  - `set_verbose_output_during_compilation true`
+##### Problematic IDE versions
+Some older versions of the Arduino IDE have bugs or limitations that may cause problems if used with this script:
+- 1.5.1 and older - The command line interface was added in 1.5.2, thus no version older than that can be used.
+- 1.5.4 and older - Do not support board-specific parameters, set by custom **Tools** menu items.
+- 1.5.5 and older - Do not support setting preferences (`--pref`), thus the sketchbook folder argument of `set_parameters` will not be used.
+- 1.5.5-r2 and older - Don't recognize libraries that have a library.properties` file that doesn't define a `core-dependencies` property. The file include is successful but compilation of sketches that use the library functions will fail.
+- 1.5.6 and older - `-` or `.` are not allowed in sketch or library folder names. If any are present the Arduino IDE will hang indefinitely when it's executed.
+- 1.6.2 - Moves its hardware packages to the .arduino15 folder, causing all other IDE versions to use those cores, some of which are not compatible. For this reason 1.6.2 has been removed from the default list of versions but may still be specified via the `IDE_VERSIONS` argument.
+- 1.6.3 and older - Do not support installing boards (`--install-boards`), thus `install_package` can't be used.
+
+#### Contributing
+Pull requests or issue reports are welcome! Please see the [contribution rules](https://github.com/per1234/arduino-ci-script/blob/master/CONTRIBUTING.md) for instructions.

--- a/avr/travis-ci/arduino-ci-script/arduino-ci-script.sh
+++ b/avr/travis-ci/arduino-ci-script/arduino-ci-script.sh
@@ -1,0 +1,1186 @@
+#!/bin/bash
+# This script is used to automate continuous integration tasks for Arduino projects
+# https://github.com/per1234/arduino-ci-script
+
+
+# Based on https://github.com/adafruit/travis-ci-arduino/blob/eeaeaf8fa253465d18785c2bb589e14ea9893f9f/install.sh#L11
+# It seems that arrays can't been seen in other functions. So instead I'm setting $IDE_VERSIONS to a string that is the command to create the array
+readonly ARDUINO_CI_SCRIPT_IDE_VERSION_LIST_ARRAY_DECLARATION="declare -a -r IDEversionListArray="
+
+# https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc#history shows CLI was added in IDE 1.5.2, Boards and Library Manager support added in 1.6.4
+# This is a list of every version of the Arduino IDE that supports CLI. As new versions are released they will be added to the list.
+# The newest IDE version must always be placed at the end of the array because the code for setting $NEWEST_INSTALLED_IDE_VERSION assumes that
+# Arduino IDE 1.6.2 has the nasty behavior of moving the included hardware cores to the .arduino15 folder, causing those versions to be used for all builds after Arduino IDE 1.6.2 is used. For this reason 1.6.2 has been left off the list.
+readonly ARDUINO_CI_SCRIPT_FULL_IDE_VERSION_LIST_ARRAY="${ARDUINO_CI_SCRIPT_IDE_VERSION_LIST_ARRAY_DECLARATION}"'("1.5.2" "1.5.3" "1.5.4" "1.5.5" "1.5.6" "1.5.6-r2" "1.5.7" "1.5.8" "1.6.0" "1.6.1" "1.6.3" "1.6.4" "1.6.5" "1.6.5-r4" "1.6.5-r5" "1.6.6" "1.6.7" "1.6.8" "1.6.9" "1.6.10" "1.6.11" "1.6.12" "1.6.13" "1.8.0" "1.8.1" "1.8.2" "1.8.3" "1.8.4" "1.8.5" "hourly")'
+
+
+readonly ARDUINO_CI_SCRIPT_TEMPORARY_FOLDER="${HOME}/temporary/arduino-ci-script"
+readonly ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER="arduino"
+readonly ARDUINO_CI_SCRIPT_VERIFICATION_OUTPUT_FILENAME="${ARDUINO_CI_SCRIPT_TEMPORARY_FOLDER}/verification_output.txt"
+readonly ARDUINO_CI_SCRIPT_REPORT_FILENAME="travis_ci_job_report_$(printf '%05d\n' "${TRAVIS_BUILD_NUMBER}").$(printf '%03d\n' "$(echo "$TRAVIS_JOB_NUMBER" | cut -d'.' -f 2)").tsv"
+readonly ARDUINO_CI_SCRIPT_REPORT_FOLDER="${HOME}/arduino-ci-script_report"
+readonly ARDUINO_CI_SCRIPT_REPORT_FILE_PATH="${ARDUINO_CI_SCRIPT_REPORT_FOLDER}/${ARDUINO_CI_SCRIPT_REPORT_FILENAME}"
+# The arduino manpage(https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc#exit-status) documents a range of exit statuses. These exit statuses indicate success, invalid arduino command, or compilation failed due to legitimate code errors. arduino sometimes returns other exit statuses that may indicate problems that may go away after a retry.
+readonly ARDUINO_CI_SCRIPT_HIGHEST_ACCEPTABLE_ARDUINO_EXIT_STATUS=4
+readonly ARDUINO_CI_SCRIPT_SKETCH_VERIFY_RETRIES=3
+readonly ARDUINO_CI_SCRIPT_REPORT_PUSH_RETRIES=10
+
+readonly ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS=0
+readonly ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS=1
+
+# Arduino IDE 1.8.2 and newer generates a ton of garbage output (appears to be something related to jmdns) that must be filtered for the log to be readable and to avoid exceeding the maximum log length
+readonly ARDUINO_CI_SCRIPT_ARDUINO_OUTPUT_FILTER_REGEX='(^\[SocketListener\(travis-job-*|^  *[0-9][0-9]*: [0-9a-g][0-9a-g]*|^dns\[query,[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*:[0-9][0-9]*, length=[0-9][0-9]*, id=|^dns\[response,[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*:[0-9][0-9]*, length=[0-9][0-9]*, id=|^questions:$|\[DNSQuestion@|^\.\]$|^\.\]\]$|^.\.\]$|^.\.\]\]$)'
+
+# Default value
+ARDUINO_CI_SCRIPT_TOTAL_SKETCH_BUILD_FAILURE_COUNT=0
+
+
+# Create the folder if it doesn't exist
+function create_folder()
+{
+  local -r folderName="$1"
+  if ! [[ -d "$folderName" ]]; then
+    # shellcheck disable=SC2086
+    mkdir --parents $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "$folderName"
+  fi
+}
+
+
+function set_script_verbosity()
+{
+  enable_verbosity
+
+  ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL="$1"
+
+  if [[ "$ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL" == "true" ]]; then
+    ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL=1
+  fi
+
+  if [[ "$ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL" -eq 1 ]]; then
+    ARDUINO_CI_SCRIPT_VERBOSITY_OPTION="--verbose"
+    ARDUINO_CI_SCRIPT_QUIET_OPTION=""
+    # Show stderr only
+    ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT="1>/dev/null"
+  elif [[ "$ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL" -eq 2 ]]; then
+    ARDUINO_CI_SCRIPT_VERBOSITY_OPTION="--verbose"
+    ARDUINO_CI_SCRIPT_QUIET_OPTION=""
+    # Show stdout and stderr
+    ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT=""
+  else
+    ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL=0
+    ARDUINO_CI_SCRIPT_VERBOSITY_OPTION=""
+    # cabextract only takes the short option name so this is more universally useful than --quiet
+    ARDUINO_CI_SCRIPT_QUIET_OPTION="-q"
+    # Don't show stderr or stdout
+    ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT="&>/dev/null"
+  fi
+
+  disable_verbosity
+}
+
+
+# Deprecated, use set_script_verbosity
+function set_verbose_script_output()
+{
+  set_script_verbosity 1
+}
+
+
+# Deprecated, use set_script_verbosity
+function set_more_verbose_script_output()
+{
+  set_script_verbosity 2
+}
+
+
+# Turn on verbosity based on the preferences set by set_script_verbosity
+function enable_verbosity()
+{
+  # Store previous verbosity settings so they can be set back to their original values at the end of the function
+  shopt -q -o verbose
+  ARDUINO_CI_SCRIPT_PREVIOUS_VERBOSE_SETTING="$?"
+
+  shopt -q -o xtrace
+  ARDUINO_CI_SCRIPT_PREVIOUS_XTRACE_SETTING="$?"
+
+  if [[ "$ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL" -gt 0 ]]; then
+    # "Print shell input lines as they are read."
+    # https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
+    set -o verbose
+  fi
+  if [[ "$ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL" -gt 1 ]]; then
+    # "Print a trace of simple commands, for commands, case commands, select commands, and arithmetic for commands and their arguments or associated word lists after they are expanded and before they are executed. The value of the PS4 variable is expanded and the resultant value is printed before the command and its expanded arguments."
+    # https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
+    set -o xtrace
+  fi
+}
+
+
+# Return verbosity settings to their previous values
+function disable_verbosity()
+{
+  if [[ "$ARDUINO_CI_SCRIPT_PREVIOUS_VERBOSE_SETTING" == "0" ]]; then
+    set -o verbose
+  else
+    set +o verbose
+  fi
+
+  if [[ "$ARDUINO_CI_SCRIPT_PREVIOUS_XTRACE_SETTING" == "0" ]]; then
+    set -o xtrace
+  else
+    set +o xtrace
+  fi
+}
+
+
+# Verbosity and, in some cases, errexit must be disabled before an early return from a public function, this allows it to be done in a single line instead of two
+function return_handler()
+{
+  local -r exitStatus="$1"
+
+  # If exit status is success and errexit is enabled then it must be disabled before exiting the script because errexit must be disabled by default and only enabled in the functions that specifically require it.
+  # If exit status is not success then errexit should not be disabled, otherwise Travis CI won't fail the build even though the exit status was failure.
+  if [[ "$exitStatus" == "$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS" ]] && shopt -q -o errexit; then
+      set +o errexit
+  fi
+
+  disable_verbosity
+
+  return "$exitStatus"
+}
+
+
+function set_application_folder()
+{
+  enable_verbosity
+
+  ARDUINO_CI_SCRIPT_APPLICATION_FOLDER="$1"
+
+  disable_verbosity
+}
+
+
+function set_sketchbook_folder()
+{
+  enable_verbosity
+
+  ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER="$1"
+
+  # Create the sketchbook folder if it doesn't already exist
+  create_folder "$ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER"
+
+  # Set sketchbook location preference if the IDE is already installed
+  if [[ "$INSTALLED_IDE_VERSION_LIST_ARRAY" != "" ]]; then
+    set_ide_preference "sketchbook.path=$ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER"
+  fi
+
+  disable_verbosity
+}
+
+
+# Deprecated
+function set_parameters()
+{
+  set_application_folder "$1"
+  set_sketchbook_folder "$2"
+}
+
+
+# Check for errors with the board definition that don't affect sketch verification
+function set_board_testing()
+{
+  enable_verbosity
+
+  ARDUINO_CI_SCRIPT_TEST_BOARD="$1"
+
+  disable_verbosity
+}
+
+
+# Check for errors with libraries that don't affect sketch verification
+function set_library_testing()
+{
+  enable_verbosity
+
+  ARDUINO_CI_SCRIPT_TEST_LIBRARY="$1"
+
+  disable_verbosity
+}
+
+
+# Install all specified versions of the Arduino IDE
+function install_ide()
+{
+  enable_verbosity
+
+  local -r startIDEversion="$1"
+  local -r endIDEversion="$2"
+
+  # https://docs.travis-ci.com/user/customizing-the-build/#Implementing-Complex-Build-Steps
+  # set -o errexit will cause the script to exit as soon as any command returns a non-zero exit status. Without this the success of the function call is determined by the exit status of the last command in the function
+  set -o errexit
+
+  generate_ide_version_list_array "$ARDUINO_CI_SCRIPT_FULL_IDE_VERSION_LIST_ARRAY" "$startIDEversion" "$endIDEversion"
+  INSTALLED_IDE_VERSION_LIST_ARRAY="$ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY"
+
+  # Set "$NEWEST_INSTALLED_IDE_VERSION"
+  determine_ide_version_extremes "$INSTALLED_IDE_VERSION_LIST_ARRAY"
+  NEWEST_INSTALLED_IDE_VERSION="$ARDUINO_CI_SCRIPT_DETERMINED_NEWEST_IDE_VERSION"
+
+  if [[ "$ARDUINO_CI_SCRIPT_APPLICATION_FOLDER" == "" ]]; then
+    echo "ERROR: Application folder was not set. Please use the set_application_folder function to define the location of the application folder."
+    return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+  fi
+  create_folder "$ARDUINO_CI_SCRIPT_APPLICATION_FOLDER"
+
+  # This runs the command contained in the $INSTALLED_IDE_VERSION_LIST_ARRAY string, thus declaring the array locally as $IDEversionListArray. This must be done in any function that uses the array
+  # Dummy declaration to fix the "referenced but not assigned" warning.
+  local IDEversionListArray
+  eval "$INSTALLED_IDE_VERSION_LIST_ARRAY"
+  local IDEversion
+  for IDEversion in "${IDEversionListArray[@]}"; do
+    if [[ "$ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL" -eq 0 ]]; then
+      # If the download/installation process is going slowly when installing a lot of IDE versions this function may cause the build to fail due to exceeding Travis CI's 10 minutes without log output timeout so it's necessary to periodically print something.
+      echo "Installing: $IDEversion"
+    fi
+    # Determine download file extension
+    local tgzExtensionVersionsRegex="1.5.[0-9]"
+    if [[ "$IDEversion" =~ $tgzExtensionVersionsRegex ]]; then
+      # The download file extension prior to 1.6.0 is .tgz
+      local downloadFileExtension="tgz"
+    else
+      local downloadFileExtension="tar.xz"
+    fi
+
+    if [[ "$IDEversion" == "hourly" ]]; then
+      # Deal with the inaccurate name given to the hourly build download
+      local downloadVersion="nightly"
+    else
+      local downloadVersion="$IDEversion"
+    fi
+
+    wget --no-verbose $ARDUINO_CI_SCRIPT_QUIET_OPTION "http://downloads.arduino.cc/arduino-${downloadVersion}-linux64.${downloadFileExtension}"
+    tar --extract --file="arduino-${downloadVersion}-linux64.${downloadFileExtension}"
+    rm $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "arduino-${downloadVersion}-linux64.${downloadFileExtension}"
+    mv $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "arduino-${downloadVersion}" "$ARDUINO_CI_SCRIPT_APPLICATION_FOLDER/arduino-${IDEversion}"
+  done
+
+  set_ide_preference "compiler.warning_level=all"
+
+  # If a sketchbook location has been defined then set the location in the Arduino IDE preferences
+  if [[ -d "$ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER" ]]; then
+    set_ide_preference "sketchbook.path=$ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER"
+  fi
+
+  # Return errexit to the default state
+  set +o errexit
+
+  disable_verbosity
+}
+
+
+# Generate an array of Arduino IDE versions as a subset of the list provided in the base array defined by the start and end versions
+# This function allows the same code to be shared by install_ide and build_sketch. The generated array is "returned" as a global named "$ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY"
+function generate_ide_version_list_array()
+{
+  local -r baseIDEversionArray="$1"
+  local startIDEversion="$2"
+  local endIDEversion="$3"
+
+  # Convert "oldest" or "newest" to actual version numbers
+  determine_ide_version_extremes "$baseIDEversionArray"
+  if [[ "$startIDEversion" == "oldest" ]]; then
+    startIDEversion="$ARDUINO_CI_SCRIPT_DETERMINED_OLDEST_IDE_VERSION"
+  elif [[ "$startIDEversion" == "newest" ]]; then
+    startIDEversion="$ARDUINO_CI_SCRIPT_DETERMINED_NEWEST_IDE_VERSION"
+  fi
+
+  if [[ "$endIDEversion" == "oldest" ]]; then
+    endIDEversion="$ARDUINO_CI_SCRIPT_DETERMINED_OLDEST_IDE_VERSION"
+  elif [[ "$endIDEversion" == "newest" ]]; then
+    endIDEversion="$ARDUINO_CI_SCRIPT_DETERMINED_NEWEST_IDE_VERSION"
+  fi
+
+
+  if [[ "$startIDEversion" == "" || "$startIDEversion" == "all" ]]; then
+    # Use the full base array
+    ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY="$baseIDEversionArray"
+
+  else
+    local rawIDElist
+    local -r IDEversionListRegex='\('
+    if [[ "$startIDEversion" =~ $IDEversionListRegex ]]; then
+      # IDE versions list was supplied
+      # Convert it to a temporary array
+      local -r suppliedIDEversionListArray="${ARDUINO_CI_SCRIPT_IDE_VERSION_LIST_ARRAY_DECLARATION}${startIDEversion}"
+      eval "$suppliedIDEversionListArray"
+      local IDEversion
+      for IDEversion in "${IDEversionListArray[@]}"; do
+        # Convert any use of "oldest" or "newest" special version names to the actual version number
+        if [[ "$IDEversion" == "oldest" ]]; then
+          IDEversion="$ARDUINO_CI_SCRIPT_DETERMINED_OLDEST_IDE_VERSION"
+        elif [[ "$IDEversion" == "newest" ]]; then
+          IDEversion="$ARDUINO_CI_SCRIPT_DETERMINED_NEWEST_IDE_VERSION"
+        fi
+        # Add the version to the array
+        rawIDElist="${rawIDElist} "'"'"$IDEversion"'"'
+      done
+
+    elif [[ "$endIDEversion" == "" ]]; then
+      # Only a single version was specified
+      rawIDElist="$rawIDElist"'"'"$startIDEversion"'"'
+
+    else
+      # A version range was specified
+      eval "$baseIDEversionArray"
+      local IDEversion
+      for IDEversion in "${IDEversionListArray[@]}"; do
+        if [[ "$IDEversion" == "$startIDEversion" ]]; then
+          # Start of the list reached, set a flag
+          local -r listIsStarted="true"
+        fi
+
+        if [[ "$listIsStarted" == "true" ]]; then
+          # Add the version to the list
+          rawIDElist="${rawIDElist} "'"'"$IDEversion"'"'
+        fi
+
+        if [[ "$IDEversion" == "$endIDEversion" ]]; then
+          # End of the list was reached, exit the loop
+          break
+        fi
+      done
+    fi
+
+    # Turn the raw IDE version list into an array
+    declare -a -r rawIDElistArray="(${rawIDElist})"
+
+    # Remove duplicates from list https://stackoverflow.com/a/13648438
+    # shellcheck disable=SC2207
+    readonly local uniqueIDElistArray=($(echo "${rawIDElistArray[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+
+    # Generate ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY
+    ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY="$ARDUINO_CI_SCRIPT_IDE_VERSION_LIST_ARRAY_DECLARATION"'('
+    for uniqueIDElistArrayIndex in "${!uniqueIDElistArray[@]}"; do
+      ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY="${ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY} "'"'"${uniqueIDElistArray[$uniqueIDElistArrayIndex]}"'"'
+    done
+    ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY="$ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY"')'
+  fi
+}
+
+
+# Determine the oldest and newest (non-hourly unless hourly is the only version on the list) IDE version in the provided array
+# The determined versions are "returned" by setting the global variables "$ARDUINO_CI_SCRIPT_DETERMINED_OLDEST_IDE_VERSION" and "$ARDUINO_CI_SCRIPT_DETERMINED_NEWEST_IDE_VERSION"
+function determine_ide_version_extremes()
+{
+  local -r baseIDEversionArray="$1"
+
+  # Reset the variables from any value they were assigned the last time the function was ran
+  ARDUINO_CI_SCRIPT_DETERMINED_OLDEST_IDE_VERSION=""
+  ARDUINO_CI_SCRIPT_DETERMINED_NEWEST_IDE_VERSION=""
+
+  # Determine the oldest and newest (non-hourly) IDE version in the base array
+  eval "$baseIDEversionArray"
+  local IDEversion
+  for IDEversion in "${IDEversionListArray[@]}"; do
+    if [[ "$ARDUINO_CI_SCRIPT_DETERMINED_OLDEST_IDE_VERSION" == "" ]]; then
+      ARDUINO_CI_SCRIPT_DETERMINED_OLDEST_IDE_VERSION="$IDEversion"
+    fi
+    if [[ "$ARDUINO_CI_SCRIPT_DETERMINED_NEWEST_IDE_VERSION" == "" || "$IDEversion" != "hourly" ]]; then
+      ARDUINO_CI_SCRIPT_DETERMINED_NEWEST_IDE_VERSION="$IDEversion"
+    fi
+  done
+}
+
+
+function set_ide_preference()
+{
+  local -r preferenceString="$1"
+
+  # --pref option is only supported by Arduino IDE 1.5.6 and newer
+  local -r unsupportedPrefOptionVersionsRegex="1.5.[0-5]"
+  if ! [[ "$NEWEST_INSTALLED_IDE_VERSION" =~ $unsupportedPrefOptionVersionsRegex ]]; then
+    install_ide_version "$NEWEST_INSTALLED_IDE_VERSION"
+
+    # --save-prefs was added in Arduino IDE 1.5.8
+    local -r unsupportedSavePrefsOptionVersionsRegex="1.5.[6-7]"
+    if ! [[ "$NEWEST_INSTALLED_IDE_VERSION" =~ $unsupportedSavePrefsOptionVersionsRegex ]]; then
+      # shellcheck disable=SC2086
+      eval \"${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/${ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER}/arduino\" --pref "$preferenceString" --save-prefs "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
+    else
+      # Arduino IDE 1.5.6 - 1.5.7 load the GUI if you only set preferences without doing a verify. So I am doing an unnecessary verification just to set the preferences in those versions. Definitely a hack but I prefer to keep the preferences setting code all here instead of cluttering build_sketch and this will pretty much never be used.
+      # shellcheck disable=SC2086
+      eval \"${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/${ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER}/arduino\" --pref "$preferenceString" --verify "${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
+    fi
+  fi
+}
+
+
+function install_ide_version()
+{
+  local -r IDEversion="$1"
+
+  # Create a symbolic link so that the Arduino IDE can always be referenced from the same path no matter which version is being used.
+  ln --symbolic --force $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/arduino-${IDEversion}" "${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/${ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER}"
+}
+
+
+# Install hardware packages
+function install_package()
+{
+  enable_verbosity
+
+  set -o errexit
+
+  local -r URLregex="://"
+  if [[ "$1" =~ $URLregex ]]; then
+    # First argument is a URL, do a manual hardware package installation
+    # Note: Assumes the package is in the root of the download and has the correct folder structure (e.g. architecture folder added in Arduino IDE 1.5+)
+
+    local -r packageURL="$1"
+
+    # Create the hardware folder if it doesn't exist
+    create_folder "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/hardware"
+
+    if [[ "$packageURL" =~ \.git$ ]]; then
+      # Clone the repository
+      local -r branchName="$2"
+
+      cd "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/hardware"
+
+      if [[ "$branchName" == "" ]]; then
+        git clone --quiet "$packageURL"
+      else
+        git clone --quiet --branch "$branchName" "$packageURL"
+      fi
+    else
+      cd "$ARDUINO_CI_SCRIPT_TEMPORARY_FOLDER"
+
+      # Delete everything from the temporary folder
+      find ./ -mindepth 1 -delete
+
+      # Download the package
+      wget --no-verbose $ARDUINO_CI_SCRIPT_QUIET_OPTION "$packageURL"
+
+      # Uncompress the package
+      extract ./*.*
+
+      # Delete all files from the temporary folder
+      find ./ -type f -maxdepth 1 -delete
+
+      # Install the package
+      mv $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./* "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/hardware/"
+    fi
+
+  elif [[ "$1" == "" ]]; then
+    # Install hardware package from this repository
+    # https://docs.travis-ci.com/user/environment-variables#Global-Variables
+    local packageName
+    packageName="$(echo "$TRAVIS_REPO_SLUG" | cut -d'/' -f 2)"
+    mkdir --parents $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/hardware/$packageName"
+    cd "$TRAVIS_BUILD_DIR"
+    cp --recursive $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./* "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/hardware/${packageName}"
+    # * doesn't copy .travis.yml but that file will be present in the user's installation so it should be there for the tests too
+    cp $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "${TRAVIS_BUILD_DIR}/.travis.yml" "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/hardware/${packageName}"
+
+  else
+    # Install package via Boards Manager
+
+    local -r packageID="$1"
+    local -r packageURL="$2"
+
+    # Check if Arduino IDE is installed
+    if [[ "$INSTALLED_IDE_VERSION_LIST_ARRAY" == "" ]]; then
+      echo "ERROR: Installing a hardware package via Boards Manager requires the Arduino IDE to be installed. Please call install_ide before this command."
+      return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+    fi
+
+    # Check if the newest installed IDE version supports --install-boards
+    local -r unsupportedInstallBoardsOptionVersionsRange1regex="1.5.[0-9]"
+    local -r unsupportedInstallBoardsOptionVersionsRange2regex="1.6.[0-3]"
+    if [[ "$NEWEST_INSTALLED_IDE_VERSION" =~ $unsupportedInstallBoardsOptionVersionsRange1regex || "$NEWEST_INSTALLED_IDE_VERSION" =~ $unsupportedInstallBoardsOptionVersionsRange2regex ]]; then
+      echo "ERROR: --install-boards option is not supported by the newest version of the Arduino IDE you have installed. You must have Arduino IDE 1.6.4 or newer installed to use this function."
+      return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+    else
+      # Temporarily install the latest IDE version to use for the package installation
+      install_ide_version "$NEWEST_INSTALLED_IDE_VERSION"
+
+      # If defined add the boards manager URL to preferences
+      if [[ "$packageURL" != "" ]]; then
+
+        # grep returns 1 when a line matches the regular expression so it's necessary to unset errexit
+        set +o errexit
+        # shellcheck disable=SC2086
+        eval \"${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/${ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER}/arduino\" --pref boardsmanager.additional.urls="$packageURL" --save-prefs "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT" | tr -Cd '[:print:]\n\t' | grep --extended-regexp --invert-match "$ARDUINO_CI_SCRIPT_ARDUINO_OUTPUT_FILTER_REGEX"; local -r arduinoPreferenceSettingExitStatus="${PIPESTATUS[0]}"
+        set -o errexit
+        # this is required because otherwise the exit status of arduino is ignored
+        if [[ "$arduinoPreferenceSettingExitStatus" != "$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS" ]]; then
+          return_handler "$arduinoPreferenceSettingExitStatus"
+        fi
+      fi
+
+      # Install the package
+      # grep returns 1 when a line matches the regular expression so it's necessary to unset errexit
+      set +o errexit
+      # shellcheck disable=SC2086
+      eval \"${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/${ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER}/arduino\" --install-boards "$packageID" "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT" | tr -Cd '[:print:]\n\t' | grep --extended-regexp --invert-match "$ARDUINO_CI_SCRIPT_ARDUINO_OUTPUT_FILTER_REGEX"; local -r arduinoInstallPackageExitStatus="${PIPESTATUS[0]}"
+      set -o errexit
+      # this is required because otherwise the exit status of arduino is ignored
+      if [[ "$arduinoInstallPackageExitStatus" != "$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS" ]]; then
+        return_handler "$arduinoPreferenceSettingExitStatus"
+      fi
+
+    fi
+  fi
+
+  set +o errexit
+
+  disable_verbosity
+}
+
+
+function install_library()
+{
+  enable_verbosity
+
+  set -o errexit
+
+  local -r libraryIdentifier="$1"
+
+  # Create the libraries folder if it doesn't already exist
+  create_folder "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/libraries"
+
+  local -r URLregex="://"
+  if [[ "$libraryIdentifier" =~ $URLregex ]]; then
+    # The argument is a URL
+    # Note: this assumes the library is in the root of the file
+    if [[ "$libraryIdentifier" =~ \.git$ ]]; then
+      # Clone the repository
+      local -r branchName="$2"
+      local -r newFolderName="$3"
+
+      cd "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/libraries"
+
+      if [[ "$branchName" == "" && "$newFolderName" == "" ]]; then
+        git clone --quiet "$libraryIdentifier"
+      elif [[ "$branchName" == "" ]]; then
+        git clone --quiet "$libraryIdentifier" "$newFolderName"
+      elif [[ "$newFolderName" == "" ]]; then
+        git clone --quiet --branch "$branchName" "$libraryIdentifier"
+      else
+        git clone --quiet --branch "$branchName" "$libraryIdentifier" "$newFolderName"
+      fi
+    else
+      # Assume it's a compressed file
+      local -r newFolderName="$2"
+      # Download the file to the temporary folder
+      cd "$ARDUINO_CI_SCRIPT_TEMPORARY_FOLDER"
+
+      # Delete everything from the temporary folder
+      find ./ -mindepth 1 -delete
+
+      wget --no-verbose $ARDUINO_CI_SCRIPT_QUIET_OPTION "$libraryIdentifier"
+
+      extract ./*.*
+
+      # Delete all files from the temporary folder
+      find ./ -type f -maxdepth 1 -delete
+
+      # Install the library
+      mv $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./* "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/libraries/${newFolderName}"
+    fi
+
+  elif [[ "$libraryIdentifier" == "" ]]; then
+    # Install library from the repository
+    # https://docs.travis-ci.com/user/environment-variables#Global-Variables
+    local libraryName
+    libraryName="$(echo "$TRAVIS_REPO_SLUG" | cut -d'/' -f 2)"
+    mkdir --parents $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/libraries/$libraryName"
+    cd "$TRAVIS_BUILD_DIR"
+    cp --recursive $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION ./* "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/libraries/${libraryName}"
+    # * doesn't copy .travis.yml but that file will be present in the user's installation so it should be there for the tests too
+    cp $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "${TRAVIS_BUILD_DIR}/.travis.yml" "${ARDUINO_CI_SCRIPT_SKETCHBOOK_FOLDER}/libraries/${libraryName}"
+
+  else
+    # Install a library that is part of the Library Manager index
+
+    # Check if Arduino IDE is installed
+    if [[ "$INSTALLED_IDE_VERSION_LIST_ARRAY" == "" ]]; then
+      echo "ERROR: Installing a library via Library Manager requires the Arduino IDE to be installed. Please call install_ide before this command."
+      return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+    fi
+
+    # Check if the newest installed IDE version supports --install-library
+    local -r unsupportedInstallLibraryOptionVersionsRange1regex="1.5.[0-9]"
+    local -r unsupportedInstallLibraryOptionVersionsRange2regex="1.6.[0-3]"
+    if [[ "$NEWEST_INSTALLED_IDE_VERSION" =~ $unsupportedInstallLibraryOptionVersionsRange1regex || "$NEWEST_INSTALLED_IDE_VERSION" =~ $unsupportedInstallLibraryOptionVersionsRange2regex ]]; then
+      echo "ERROR: --install-library option is not supported by the newest version of the Arduino IDE you have installed. You must have Arduino IDE 1.6.4 or newer installed to use this function."
+      return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+    else
+      local -r libraryName="$1"
+
+      # Temporarily install the latest IDE version to use for the library installation
+      install_ide_version "$NEWEST_INSTALLED_IDE_VERSION"
+
+       # Install the library
+      # shellcheck disable=SC2086
+      eval \"${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/${ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER}/arduino\" --install-library "$libraryName" "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
+
+    fi
+  fi
+
+  set +o errexit
+
+  disable_verbosity
+}
+
+
+# Extract common file formats
+# https://github.com/xvoland/Extract
+function extract
+{
+  if [ -z "$1" ]; then
+    # display usage if no parameters given
+    echo "Usage: extract <path/file_name>.<zip|rar|bz2|gz|tar|tbz2|tgz|Z|7z|xz|ex|tar.bz2|tar.gz|tar.xz>"
+    echo "       extract <path/file_name_1.ext> [path/file_name_2.ext] [path/file_name_3.ext]"
+    return "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+  else
+    local filename
+    for filename in "$@"
+    do
+      if [ -f "$filename" ]; then
+        case "${filename%,}" in
+          *.tar.bz2|*.tar.gz|*.tar.xz|*.tbz2|*.tgz|*.txz|*.tar)
+            tar --extract --file="$filename"
+          ;;
+          *.lzma)
+            unlzma $ARDUINO_CI_SCRIPT_QUIET_OPTION ./"$filename"
+          ;;
+          *.bz2)
+            bunzip2 $ARDUINO_CI_SCRIPT_QUIET_OPTION ./"$filename"
+          ;;
+          *.rar)
+            eval unrar x -ad ./"$filename" "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
+          ;;
+          *.gz)
+            gunzip ./"$filename"
+          ;;
+          *.zip)
+            unzip -qq ./"$filename"
+          ;;
+          *.z)
+            eval uncompress ./"$filename" "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
+          ;;
+          *.7z|*.arj|*.cab|*.chm|*.deb|*.dmg|*.iso|*.lzh|*.msi|*.rpm|*.udf|*.wim|*.xar)
+            7z x ./"$filename"
+          ;;
+          *.xz)
+            unxz $ARDUINO_CI_SCRIPT_QUIET_OPTION ./"$filename"
+          ;;
+          *.exe)
+            cabextract $ARDUINO_CI_SCRIPT_QUIET_OPTION ./"$filename"
+          ;;
+          *)
+            echo "extract: '$filename' - unknown archive method"
+            return "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+          ;;
+        esac
+      else
+        echo "extract: '$filename' - file does not exist"
+        return "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+      fi
+    done
+  fi
+}
+
+
+function set_verbose_output_during_compilation()
+{
+  enable_verbosity
+
+  local -r verboseOutputDuringCompilation="$1"
+  if [[ "$verboseOutputDuringCompilation" == "true" ]]; then
+    ARDUINO_CI_SCRIPT_DETERMINED_VERBOSE_BUILD="--verbose"
+  else
+    ARDUINO_CI_SCRIPT_DETERMINED_VERBOSE_BUILD=""
+  fi
+
+  disable_verbosity
+}
+
+
+# Verify the sketch
+function build_sketch()
+{
+  enable_verbosity
+
+  local -r sketchPath="$1"
+  local -r boardID="$2"
+  local -r allowFail="$3"
+  local -r startIDEversion="$4"
+  local -r endIDEversion="$5"
+
+  # Set default value for buildSketchExitStatus
+  local buildSketchExitStatus="$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS"
+
+  generate_ide_version_list_array "$INSTALLED_IDE_VERSION_LIST_ARRAY" "$startIDEversion" "$endIDEversion"
+
+  if [[ "$ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY" == "$ARDUINO_CI_SCRIPT_IDE_VERSION_LIST_ARRAY_DECLARATION"'()' ]]; then
+    echo "ERROR: The IDE version(s) specified are not installed"
+    return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+  fi
+
+  eval "$ARDUINO_CI_SCRIPT_GENERATED_IDE_VERSION_LIST_ARRAY"
+  local IDEversion
+  for IDEversion in "${IDEversionListArray[@]}"; do
+    # Install the IDE
+    # This must be done before searching for sketches in case the path specified is in the Arduino IDE installation folder
+    install_ide_version "$IDEversion"
+
+    # The package_index files installed by some versions of the IDE (1.6.5, 1.6.5) can cause compilation to fail for other versions (1.6.5-r4, 1.6.5-r5). Attempting to install a dummy package ensures that the correct version of those files will be installed before the sketch verification.
+    # Check if the newest installed IDE version supports --install-boards
+    local unsupportedInstallBoardsOptionVersionsRange1regex="1.5.[0-9]"
+    local unsupportedInstallBoardsOptionVersionsRange2regex="1.6.[0-3]"
+    if ! [[ "$IDEversion" =~ $unsupportedInstallBoardsOptionVersionsRange1regex || "$IDEversion" =~ $unsupportedInstallBoardsOptionVersionsRange2regex ]]; then
+      # shellcheck disable=SC2086
+      eval \"${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/${ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER}/arduino\" --install-boards arduino:dummy "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
+      if [[ "$ARDUINO_CI_SCRIPT_VERBOSITY_LEVEL" -gt 1 ]]; then
+        # The warning is printed to stdout
+        echo "NOTE: The warning above \"Selected board is not available\" is caused intentionally and does not indicate a problem."
+      fi
+    fi
+
+    if [[ "$sketchPath" =~ \.ino$ || "$sketchPath" =~ \.pde$ ]]; then
+      # A sketch was specified
+      if ! [[ -f "$sketchPath" ]]; then
+        echo "ERROR: Specified sketch: $sketchPath doesn't exist"
+        buildSketchExitStatus="$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+      elif ! build_this_sketch "$sketchPath" "$boardID" "$IDEversion" "$allowFail"; then
+        # build_this_sketch returned a non-zero exit status
+        buildSketchExitStatus="$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+      fi
+    else
+      # Search for all sketches in the path and put them in an array
+      local sketchFound="false"
+      # https://github.com/koalaman/shellcheck/wiki/SC2207
+      declare -a sketches
+      mapfile -t sketches < <(find "$sketchPath" -name "*.pde" -o -name "*.ino")
+      local sketchName
+      for sketchName in "${sketches[@]}"; do
+        # Only verify the sketch that matches the name of the sketch folder, otherwise it will cause redundant verifications for sketches that have multiple .ino files
+        local sketchFolder
+        sketchFolder="$(echo "$sketchName" | rev | cut -d'/' -f 2 | rev)"
+        local sketchNameWithoutPathWithExtension
+        sketchNameWithoutPathWithExtension="$(echo "$sketchName" | rev | cut -d'/' -f 1 | rev)"
+        local sketchNameWithoutPathWithoutExtension
+        sketchNameWithoutPathWithoutExtension="${sketchNameWithoutPathWithExtension%.*}"
+        if [[ "$sketchFolder" == "$sketchNameWithoutPathWithoutExtension" ]]; then
+          sketchFound="true"
+          if ! build_this_sketch "$sketchName" "$boardID" "$IDEversion" "$allowFail"; then
+            # build_this_sketch returned a non-zero exit status
+            buildSketchExitStatus="$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+          fi
+        fi
+      done
+
+      if [[ "$sketchFound" == "false" ]]; then
+        echo "ERROR: No valid sketches were found in the specified path"
+        buildSketchExitStatus="$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+      fi
+    fi
+  done
+
+  disable_verbosity
+
+  return $buildSketchExitStatus
+}
+
+
+function build_this_sketch()
+{
+  # Fold this section of output in the Travis CI build log to make it easier to read
+  echo -e "travis_fold:start:build_sketch"
+
+  local -r sketchName="$1"
+  local -r boardID="$2"
+  local -r IDEversion="$3"
+  local -r allowFail="$4"
+
+  # Produce a useful label for the fold in the Travis log for this function call
+  echo "build_sketch $sketchName $boardID $IDEversion $allowFail"
+
+  # Arduino IDE 1.8.0 and 1.8.1 fail to verify a sketch if the absolute path to it is not specified
+  # http://stackoverflow.com/a/3915420/7059512
+  local absoluteSketchName
+  absoluteSketchName="$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
+
+  # Define a dummy value for arduinoExitStatus so that the while loop will run at least once
+  local arduinoExitStatus=255
+  # Retry the verification if arduino returns an exit status that indicates there may have been a temporary error not caused by a bug in the sketch or the arduino command
+  while [[ $arduinoExitStatus -gt $ARDUINO_CI_SCRIPT_HIGHEST_ACCEPTABLE_ARDUINO_EXIT_STATUS && $verifyCount -le $ARDUINO_CI_SCRIPT_SKETCH_VERIFY_RETRIES ]]; do
+    # Verify the sketch
+    # shellcheck disable=SC2086
+    "${ARDUINO_CI_SCRIPT_APPLICATION_FOLDER}/${ARDUINO_CI_SCRIPT_IDE_INSTALLATION_FOLDER}/arduino" $ARDUINO_CI_SCRIPT_DETERMINED_VERBOSE_BUILD --verify "$absoluteSketchName" --board "$boardID" 2>&1 | tr -Cd '[:print:]\n\t'  | grep --extended-regexp --invert-match "$ARDUINO_CI_SCRIPT_ARDUINO_OUTPUT_FILTER_REGEX" | tee "$ARDUINO_CI_SCRIPT_VERIFICATION_OUTPUT_FILENAME"; local arduinoExitStatus="${PIPESTATUS[0]}"
+    local verifyCount=$((verifyCount + 1))
+  done
+
+  if [[ "$arduinoExitStatus" != "$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS" ]]; then
+    # Sketch verification failed
+    local buildThisSketchExitStatus="$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+  else
+    # Sketch verification succeeded
+    local buildThisSketchExitStatus="$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS"
+
+    # Parse through the output from the sketch verification to count warnings and determine the compile size
+    local warningCount=0
+    local boardIssueCount=0
+    local libraryIssueCount=0
+    while read -r outputFileLine; do
+      # Determine program storage memory usage
+      local programStorageRegex="Sketch uses ([0-9,]+) *"
+      if [[ "$outputFileLine" =~ $programStorageRegex ]] > /dev/null; then
+        local -r programStorageWithComma=${BASH_REMATCH[1]}
+      fi
+
+      # Determine dynamic memory usage
+      local dynamicMemoryRegex="Global variables use ([0-9,]+) *"
+      if [[ "$outputFileLine" =~ $dynamicMemoryRegex ]] > /dev/null; then
+        local -r dynamicMemoryWithComma=${BASH_REMATCH[1]}
+      fi
+
+      # Increment warning count
+      local warningRegex="warning: "
+      if [[ "$outputFileLine" =~ $warningRegex ]] > /dev/null; then
+        warningCount=$((warningCount + 1))
+      fi
+
+      # Check for board issues
+      local bootloaderMissingRegex="Bootloader file specified but missing: "
+      if [[ "$outputFileLine" =~ $bootloaderMissingRegex ]] > /dev/null; then
+        local boardIssue="missing bootloader"
+        boardIssueCount=$((boardIssueCount + 1))
+      fi
+
+      local boardsDotTxtMissingRegex="Could not find boards.txt"
+      if [[ "$outputFileLine" =~ $boardsDotTxtMissingRegex ]] > /dev/null; then
+        local boardIssue="Could not find boards.txt"
+        boardIssueCount=$((boardIssueCount + 1))
+      fi
+
+      local buildDotBoardNotDefinedRegex="doesn't define a 'build.board' preference"
+      if [[ "$outputFileLine" =~ $buildDotBoardNotDefinedRegex ]] > /dev/null; then
+        local boardIssue="doesn't define a 'build.board' preference"
+        boardIssueCount=$((boardIssueCount + 1))
+      fi
+
+      # Check for library issues
+      # This is the generic "invalid library" warning that doesn't specify the reason
+      local invalidLibrarRegex1="Invalid library found in"
+      local invalidLibrarRegex2="from library$"
+      if [[ "$outputFileLine" =~ $invalidLibrarRegex1 ]] && ! [[ "$outputFileLine" =~ $invalidLibrarRegex2 ]] > /dev/null; then
+        local libraryIssue="Invalid library"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local missingNameRegex="Invalid library found in .* Missing 'name' from library"
+      if [[ "$outputFileLine" =~ $missingNameRegex ]] > /dev/null; then
+        local libraryIssue="Missing 'name' from library"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local missingVersionRegex="Invalid library found in .* Missing 'version' from library"
+      if [[ "$outputFileLine" =~ $missingVersionRegex ]] > /dev/null; then
+        local libraryIssue="Missing 'version' from library"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local missingAuthorRegex="Invalid library found in .* Missing 'author' from library"
+      if [[ "$outputFileLine" =~ $missingAuthorRegex ]] > /dev/null; then
+        local libraryIssue="Missing 'author' from library"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local missingMaintainerRegex="Invalid library found in .* Missing 'maintainer' from library"
+      if [[ "$outputFileLine" =~ $missingMaintainerRegex ]] > /dev/null; then
+        local libraryIssue="Missing 'maintainer' from library"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local missingSentenceRegex="Invalid library found in .* Missing 'sentence' from library"
+      if [[ "$outputFileLine" =~ $missingSentenceRegex ]] > /dev/null; then
+        local libraryIssue="Missing 'sentence' from library"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local missingParagraphRegex="Invalid library found in .* Missing 'paragraph' from library"
+      if [[ "$outputFileLine" =~ $missingParagraphRegex ]] > /dev/null; then
+        local libraryIssue="Missing 'paragraph' from library"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local missingURLregex="Invalid library found in .* Missing 'url' from library"
+      if [[ "$outputFileLine" =~ $missingURLregex ]] > /dev/null; then
+        local libraryIssue="Missing 'url' from library"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local invalidVersionRegex="Invalid version found:"
+      if [[ "$outputFileLine" =~ $invalidVersionRegex ]] > /dev/null; then
+        local libraryIssue="Invalid version found:"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local invalidCategoryRegex="is not valid. Setting to 'Uncategorized'"
+      if [[ "$outputFileLine" =~ $invalidCategoryRegex ]] > /dev/null; then
+        local libraryIssue="Invalid category"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+      local spuriousFolderRegex="WARNING: Spurious"
+      if [[ "$outputFileLine" =~ $spuriousFolderRegex ]] > /dev/null; then
+        local libraryIssue="Spurious folder"
+        libraryIssueCount=$((libraryIssueCount + 1))
+      fi
+
+    done < "$ARDUINO_CI_SCRIPT_VERIFICATION_OUTPUT_FILENAME"
+
+    rm $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "$ARDUINO_CI_SCRIPT_VERIFICATION_OUTPUT_FILENAME"
+
+    # Remove the stupid comma from the memory values if present
+    local -r programStorage=${programStorageWithComma//,}
+    local -r dynamicMemory=${dynamicMemoryWithComma//,}
+
+    if [[ "$boardIssue" != "" && "$ARDUINO_CI_SCRIPT_TEST_BOARD" == "true" ]]; then
+      # There was a board issue and board testing is enabled so fail the build
+      local buildThisSketchExitStatus="$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+    fi
+
+    if [[ "$libraryIssue" != "" && "$ARDUINO_CI_SCRIPT_TEST_LIBRARY" == "true" ]]; then
+      # There was a library issue and library testing is enabled so fail the build
+      local buildThisSketchExitStatus="$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+    fi
+  fi
+
+  # Add the build data to the report file
+  echo "$(date -u "+%Y-%m-%d %H:%M:%S")"$'\t'"$TRAVIS_BUILD_NUMBER"$'\t'"$TRAVIS_JOB_NUMBER"$'\t'"https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}"$'\t'"$TRAVIS_EVENT_TYPE"$'\t'"$TRAVIS_ALLOW_FAILURE"$'\t'"$TRAVIS_PULL_REQUEST"$'\t'"$TRAVIS_BRANCH"$'\t'"$TRAVIS_COMMIT"$'\t'"$TRAVIS_COMMIT_RANGE"$'\t'"${TRAVIS_COMMIT_MESSAGE%%$'\n'*}"$'\t'"$sketchName"$'\t'"$boardID"$'\t'"$IDEversion"$'\t'"$programStorage"$'\t'"$dynamicMemory"$'\t'"$warningCount"$'\t'"$allowFail"$'\t'"$arduinoExitStatus"$'\t'"$boardIssueCount"$'\t'"$boardIssue"$'\t'"$libraryIssueCount"$'\t'"$libraryIssue"$'\r' >> "$ARDUINO_CI_SCRIPT_REPORT_FILE_PATH"
+
+  # Adjust the exit status according to the allowFail setting
+  if [[ "$buildThisSketchExitStatus" == "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS" && ("$allowFail" == "true" || "$allowFail" == "require") ]]; then
+    buildThisSketchExitStatus="$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS"
+  elif [[ "$buildThisSketchExitStatus" == "$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS" && "$allowFail" == "require" ]]; then
+    buildThisSketchExitStatus="$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+  fi
+
+  if [[ "$buildThisSketchExitStatus" != "$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS" ]]; then
+    ARDUINO_CI_SCRIPT_TOTAL_SKETCH_BUILD_FAILURE_COUNT=$((ARDUINO_CI_SCRIPT_TOTAL_SKETCH_BUILD_FAILURE_COUNT + 1))
+  fi
+  ARDUINO_CI_SCRIPT_TOTAL_WARNING_COUNT=$((ARDUINO_CI_SCRIPT_TOTAL_WARNING_COUNT + warningCount + 0))
+  ARDUINO_CI_SCRIPT_TOTAL_BOARD_ISSUE_COUNT=$((ARDUINO_CI_SCRIPT_TOTAL_BOARD_ISSUE_COUNT + boardIssueCount + 0))
+  ARDUINO_CI_SCRIPT_TOTAL_LIBRARY_ISSUE_COUNT=$((ARDUINO_CI_SCRIPT_TOTAL_LIBRARY_ISSUE_COUNT + libraryIssueCount + 0))
+
+  # End the folded section of the Travis CI build log
+  echo -e "travis_fold:end:build_sketch"
+  # Add a useful message to the Travis CI build log
+
+  echo "arduino Exit Status: ${arduinoExitStatus}, Allow Failure: ${allowFail}, # Warnings: ${warningCount}, # Board Issues: ${boardIssueCount}, # Library Issues: ${libraryIssueCount}"
+
+  return $buildThisSketchExitStatus
+}
+
+
+# Print the contents of the report file
+function display_report()
+{
+  enable_verbosity
+
+  if [ -e "$ARDUINO_CI_SCRIPT_REPORT_FILE_PATH" ]; then
+    echo -e '\n\n\n**************Begin Report**************\n\n\n'
+    cat "$ARDUINO_CI_SCRIPT_REPORT_FILE_PATH"
+    echo -e '\n\n'
+    echo "Total failed sketch builds: $ARDUINO_CI_SCRIPT_TOTAL_SKETCH_BUILD_FAILURE_COUNT"
+    echo "Total warnings: $ARDUINO_CI_SCRIPT_TOTAL_WARNING_COUNT"
+    echo "Total board issues: $ARDUINO_CI_SCRIPT_TOTAL_BOARD_ISSUE_COUNT"
+    echo "Total library issues: $ARDUINO_CI_SCRIPT_TOTAL_LIBRARY_ISSUE_COUNT"
+    echo -e '\n\n'
+  else
+    echo "No report file available for this job"
+  fi
+
+  disable_verbosity
+}
+
+
+# Add the report file to a Git repository
+function publish_report_to_repository()
+{
+  enable_verbosity
+
+  local -r token="$1"
+  local -r repositoryURL="$2"
+  local -r reportBranch="$3"
+  local -r reportFolder="$4"
+  local -r doLinkComment="$5"
+
+  if [[ "$token" != "" ]] && [[ "$repositoryURL" != "" ]] && [[ "$reportBranch" != "" ]]; then
+    if [ -e "$ARDUINO_CI_SCRIPT_REPORT_FILE_PATH" ]; then
+      # Location is a repository
+      if git clone --quiet --branch "$reportBranch" "$repositoryURL" "${HOME}/report-repository"; then
+        # Clone was successful
+        create_folder "${HOME}/report-repository/${reportFolder}"
+        cp $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "$ARDUINO_CI_SCRIPT_REPORT_FILE_PATH" "${HOME}/report-repository/${reportFolder}"
+        cd "${HOME}/report-repository"
+        git add $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "${HOME}/report-repository/${reportFolder}/${ARDUINO_CI_SCRIPT_REPORT_FILENAME}"
+        git config user.email "arduino-ci-script@nospam.me"
+        git config user.name "arduino-ci-script-bot"
+        # Only pushes the current branch to the corresponding remote branch that 'git pull' uses to update the current branch.
+        git config push.default simple
+        if [[ "$TRAVIS_TEST_RESULT" != "0" ]]; then
+          local -r jobSuccessMessage="FAILED"
+        else
+          local -r jobSuccessMessage="SUCCESSFUL"
+        fi
+        # Do a pull now in case another job has finished about the same time and pushed a report after the clone happened, which would otherwise cause the push to fail. This is the last chance to pull without having to deal with a merge or rebase.
+        git pull $ARDUINO_CI_SCRIPT_QUIET_OPTION
+        git commit $ARDUINO_CI_SCRIPT_QUIET_OPTION $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION --message="Add Travis CI job ${TRAVIS_JOB_NUMBER} report (${jobSuccessMessage})" --message="Total failed sketch builds: $ARDUINO_CI_SCRIPT_TOTAL_SKETCH_BUILD_FAILURE_COUNT" --message="Total warnings: $ARDUINO_CI_SCRIPT_TOTAL_WARNING_COUNT" --message="Total board issues: $ARDUINO_CI_SCRIPT_TOTAL_BOARD_ISSUE_COUNT" --message="Total library issues: $ARDUINO_CI_SCRIPT_TOTAL_LIBRARY_ISSUE_COUNT" --message="Job log: https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}" --message="Commit: https://github.com/${TRAVIS_REPO_SLUG}/commit/${TRAVIS_COMMIT}" --message="$TRAVIS_COMMIT_MESSAGE" --message="[skip ci]"
+        local gitPushExitStatus="1"
+        local pushCount=0
+        while [[ "$gitPushExitStatus" != "$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS" && $pushCount -le $ARDUINO_CI_SCRIPT_REPORT_PUSH_RETRIES ]]; do
+          pushCount=$((pushCount + 1))
+          # Do a pull now in case another job has finished about the same time and pushed a report since the last pull. This would require a merge or rebase. Rebase should be safe since the commits will be separate files.
+          git pull $ARDUINO_CI_SCRIPT_QUIET_OPTION --rebase
+          git push $ARDUINO_CI_SCRIPT_QUIET_OPTION $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION "https://${token}@${repositoryURL#*//}"
+          gitPushExitStatus="$?"
+        done
+        rm --recursive --force "${HOME}/report-repository"
+        if [[ "$gitPushExitStatus" == "$ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS" ]]; then
+          if [[ "$doLinkComment" == "true" ]]; then
+            # Only comment if it's job 1
+            local -r firstJobRegex='\.1$'
+            if [[ "$TRAVIS_JOB_NUMBER" =~ $firstJobRegex ]]; then
+              local reportURL
+              reportURL="${repositoryURL%.*}/tree/${reportBranch}/${reportFolder}"
+              comment_report_link "$token" "$reportURL"
+            fi
+          fi
+        else
+          echo "ERROR: Failed to push to remote branch."
+          return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+        fi
+      else
+        echo "ERROR: Failed to clone branch ${reportBranch} of repository URL ${repositoryURL}. Do they exist?"
+        return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+      fi
+    else
+      echo "No report file available for this job"
+    fi
+  else
+    if [[ "$token" == "" ]]; then
+      echo "ERROR: GitHub token not specified. Failed to publish build report. See https://github.com/per1234/arduino-ci-script#publishing-job-reports for instructions."
+    fi
+    if [[ "$repositoryURL" == "" ]]; then
+      echo "ERROR: Repository URL not specified. Failed to publish build report."
+    fi
+    if [[ "$reportBranch" == "" ]]; then
+      echo "ERROR: Repository branch not specified. Failed to publish build report."
+    fi
+    return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+  fi
+
+  disable_verbosity
+}
+
+
+# Add the report file to a gist
+function publish_report_to_gist()
+{
+  enable_verbosity
+
+  local -r token="$1"
+  local -r gistURL="$2"
+  local -r doLinkComment="$3"
+
+  if [[ "$token" != "" ]] && [[ "$gistURL" != "" ]]; then
+    if [ -e "$ARDUINO_CI_SCRIPT_REPORT_FILE_PATH" ]; then
+      # Get the gist ID from the gist URL
+      local gistID
+      gistID="$(echo "$gistURL" | rev | cut -d'/' -f 1 | rev)"
+
+      # http://stackoverflow.com/a/33354920/7059512
+      # Sanitize the report file content so it can be sent via a POST request without breaking the JSON
+      # Remove \r (from Windows end-of-lines), replace tabs by \t, replace " by \", replace EOL by \n
+      local reportContent
+      reportContent=$(sed -e 's/\r//' -e's/\t/\\t/g' -e 's/"/\\"/g' "$ARDUINO_CI_SCRIPT_REPORT_FILE_PATH" | awk '{ printf($0 "\\n") }')
+
+      # Upload the report to the Gist. I have to use the here document to avoid the "Argument list too long" error from curl with long reports. Redirect output to dev/null because it dumps the whole gist to the log
+      eval curl --header "\"Authorization: token ${token}\"" --data @- "\"https://api.github.com/gists/${gistID}\"" <<curlDataHere "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
+{"files":{"${ARDUINO_CI_SCRIPT_REPORT_FILENAME}":{"content": "${reportContent}"}}}
+curlDataHere
+
+      if [[ "$doLinkComment" == "true" ]]; then
+        # Only comment if it's job 1
+        local -r firstJobRegex='\.1$'
+        if [[ "$TRAVIS_JOB_NUMBER" =~ $firstJobRegex ]]; then
+          local reportURL="${gistURL}#file-${ARDUINO_CI_SCRIPT_REPORT_FILENAME//./-}"
+          comment_report_link "$token" "$reportURL"
+        fi
+      fi
+    else
+      echo "No report file available for this job"
+    fi
+  else
+    if [[ "$token" == "" ]]; then
+      echo "ERROR: GitHub token not specified. Failed to publish build report. See https://github.com/per1234/arduino-ci-script#publishing-job-reports for instructions."
+    fi
+    if [[ "$gistURL" == "" ]]; then
+      echo "ERROR: Gist URL not specified. Failed to publish build report. See https://github.com/per1234/arduino-ci-script#publishing-job-reports for instructions."
+    fi
+    return_handler "$ARDUINO_CI_SCRIPT_FAILURE_EXIT_STATUS"
+  fi
+
+  disable_verbosity
+}
+
+
+# Leave a comment on the commit with a link to the report
+function comment_report_link()
+{
+  local -r token="$1"
+  local -r reportURL="$2"
+
+  # shellcheck disable=SC1083
+  # shellcheck disable=SC2026
+  # shellcheck disable=SC2086
+  eval curl $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION --header "\"Authorization: token ${token}\"" --data \"{'\"'body'\"':'\"'Once completed, the job reports for Travis CI [build ${TRAVIS_BUILD_NUMBER}]\(https://travis-ci.org/${TRAVIS_REPO_SLUG}/builds/${TRAVIS_BUILD_ID}\) will be found at:\\n${reportURL}'\"'}\" "\"https://api.github.com/repos/${TRAVIS_REPO_SLUG}/commits/${TRAVIS_COMMIT}/comments\"" "$ARDUINO_CI_SCRIPT_VERBOSITY_REDIRECT"
+  if [[ $? -ne $ARDUINO_CI_SCRIPT_SUCCESS_EXIT_STATUS ]]; then
+    echo "ERROR: Failed to comment link to published report location"
+  fi
+}
+
+
+# Deprecated because no longer necessary. Left only to maintain backwards compatibility
+function check_success()
+{
+  echo "The check_success function is no longer necessary and has been deprecated"
+}
+
+
+# Set default verbosity (must be called after the function definitions
+set_script_verbosity 0
+
+
+# Create the temporary folder
+create_folder "$ARDUINO_CI_SCRIPT_TEMPORARY_FOLDER"
+
+# Create the report folder
+create_folder "$ARDUINO_CI_SCRIPT_REPORT_FOLDER"
+
+
+# Add column names to report
+echo "Build Timestamp (UTC)"$'\t'"Build"$'\t'"Job"$'\t'"Job URL"$'\t'"Build Trigger"$'\t'"Allow Job Failure"$'\t'"PR#"$'\t'"Branch"$'\t'"Commit"$'\t'"Commit Range"$'\t'"Commit Message"$'\t'"Sketch Filename"$'\t'"Board ID"$'\t'"IDE Version"$'\t'"Program Storage (bytes)"$'\t'"Dynamic Memory (bytes)"$'\t'"# Warnings"$'\t'"Allow Failure"$'\t'"Exit Status"$'\t'"# Board Issues"$'\t'"Board Issue"$'\t'"# Library Issues"$'\t'"Library Issue"$'\r' > "$ARDUINO_CI_SCRIPT_REPORT_FILE_PATH"
+
+
+# Start the virtual display required by the Arduino IDE CLI: https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc#bugs
+# based on https://learn.adafruit.com/continuous-integration-arduino-and-you/testing-your-project
+/sbin/start-stop-daemon --start $ARDUINO_CI_SCRIPT_QUIET_OPTION $ARDUINO_CI_SCRIPT_VERBOSITY_OPTION --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16
+sleep 3
+export DISPLAY=:1.0


### PR DESCRIPTION
- Add arduino-ci-script subtree.
- Add .travis.yml.
- Add Travis CI build status badge to README.md.

As with MightyCore, I configured the build to only test using "landmark" IDE builds: 1.6.7, 1.6.11, 1.6.13. 1.8.0, 1.8.5, and whichever IDE version is the newest on the version list (currently 1.8.5). If you like, I can easily change it to test with the full range of IDE versions (as I did with MegaCore) since MiniCore has less libraries than MightyCore. The benefit of testing with less IDE versions is the build duration is significantly shorter (currently it's ~1.75 hr) but it means not as thorough of backwards compatibility testing.

Successful Travis CI build:
https://travis-ci.org/per1234/MiniCore/builds/339327474