### PR TITLE
Correct readme regarding *PB series installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,15 @@ Open Arduino IDE, and a new category in the boards menu called "MiniCore" will s
 #### ATmega48/88/168/328PB series
 If you plan to use the *PB series, you'll need to update to the latest version of the Arduino toolchain. At the time of writing the latest version is *1.6.206*. Here's how you install it:
 * Open Arduino IDE.
+* Open the **File > Preferences** menu item.
+* In the **Additional Boards Manager URLs** field, add:
+    ```
+    https://downloads.arduino.cc/packages/package_avr_3.6.0_index.json
+    ```
 * Open the **Tools > Board > Boards Manager...** menu item.
 * Wait for the platform indexes to finish downloading.
-* The top is named **Arduino AVR boards**. Click on this item and select the latest version in the dropdown menu.
-* Click **Install**.
+* The top is named **Arduino AVR boards**. Click on this item.
+* Click **Update**.
 * After installation is complete close the **Boards Manager** window.
 
 


### PR DESCRIPTION
*PB parts support is only available in the beta test Arduino AVR Boards toolchain, which requires a special Boards Manager URL. Reference:
https://github.com/arduino/toolchain-avr/pull/47#issue-133713450

This commit should be reverted once the Arduino AVR Boards hardware package is released which contains the new toolchain.

Resolves https://github.com/MCUdude/MiniCore/issues/44