### PR TITLE
Update Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,20 @@ env:
     # clock=1MHz_internal
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:48:bootloader=false,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
 
+    # EEPROM
+    # bootloader=false, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/EEPROM" BOARD_ID="MiniCore:avr:48:bootloader=false,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # LTO=Os_flto, clock=20MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/EEPROM" BOARD_ID="MiniCore:avr:48:bootloader=false,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # variant=modelNonP, BOD=4v3, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/EEPROM" BOARD_ID="MiniCore:avr:48:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # variant=modelPB, BOD=1v8, clock=12MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/EEPROM" BOARD_ID="MiniCore:avr:48:bootloader=false,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=disabled, clock=8MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/EEPROM" BOARD_ID="MiniCore:avr:48:bootloader=false,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1MHz_internal
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/EEPROM" BOARD_ID="MiniCore:avr:48:bootloader=false,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+
     # Optiboot_flasher
     # SerialReadWrite
     # Fails to compile "Sketch too big" for ATmega48 so this library can't be tested
@@ -217,6 +231,20 @@ env:
     # clock=1MHz_internal
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Watch_dog_timer" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
 
+    # EEPROM
+    # bootloader=true, BOD=2v7, LTO=Os, clock=16MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/EEPROM" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # LTO=Os_flto, clock=20MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/EEPROM" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # bootloader=false, BOD=4v0, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/EEPROM" BOARD_ID="MiniCore:avr:8:bootloader=false,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=disabled, clock=12MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/EEPROM" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=8MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/EEPROM" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1MHz_internal
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/EEPROM" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+
     # Optiboot_flasher
     # bootloader=true, BOD=2v7, LTO=Os, clock=16MHz_external
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
@@ -244,6 +272,34 @@ env:
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     # clock=1MHz_internal
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+
+    # SPI
+    # bootloader=true, BOD=2v7, LTO=Os, clock=16MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # LTO=Os_flto, clock=20MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # bootloader=false, BOD=4v0, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:8:bootloader=false,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=disabled, clock=12MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=8MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1MHz_internal
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+
+    # Wire
+    # bootloader=true, BOD=2v7, LTO=Os, clock=16MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # LTO=Os_flto, clock=20MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # bootloader=false, BOD=4v0, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:8:bootloader=false,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=disabled, clock=12MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=8MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1MHz_internal
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,275 +28,55 @@ env:
     # Each line in the matrix will be run as a separate job in the Travis CI build
 
     # ATmega328
-
+    # bootloader=true, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # LTO=Os_flto, clock=20MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # bootloader=false, variant=modelNonP, BOD=4v3, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:328:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # variant=modelPB, BOD=1v8, clock=12MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=disabled, clock=8MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     # clock=8MHz_internal
-    # F_CPU of 8 MHz will be fully tested for clock=8MHz_external and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
+    # F_CPU of 8 MHz has already been fully tested and the BOD and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
     - SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1MHz_internal
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
 
-    # AVR_examples
+    # ATmega168
     # bootloader=true, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
     # bootloader=false, variant=modelNonP, BOD=4v3, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:328:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:168:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     # variant=modelPB, BOD=1v8, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     # BOD=disabled, clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # Optiboot_flasher
-    # bootloader=true, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, variant=modelNonP, BOD=4v3, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:328:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # variant=modelPB, BOD=1v8, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # SoftwareSerial
-    # bootloader=true, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, variant=modelNonP, BOD=4v3, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:328:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # variant=modelPB, BOD=1v8, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # SPI
-    # bootloader=true, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, variant=modelNonP, BOD=4v3, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:328:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # variant=modelPB, BOD=1v8, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # SPI1
-    # This library is only for use with the ATmega328PB
-    # bootloader=true, variant=modelPB, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI1" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelPB,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI1" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelPB,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, BOD=4v3, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI1" BOARD_ID="MiniCore:avr:328:bootloader=false,variant=modelPB,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=1v8, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI1" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI1" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelPB,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI1" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelPB,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # Wire
-    # bootloader=true, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, variant=modelNonP, BOD=4v3, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:328:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # variant=modelPB, BOD=1v8, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # Wire1
-    # This library is only for use with the ATmega328PB
-    # bootloader=true, variant=modelPB, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire1" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelPB,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire1" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelPB,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, BOD=4v3, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire1" BOARD_ID="MiniCore:avr:328:bootloader=false,variant=modelPB,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=1v8, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire1" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire1" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelPB,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire1" BOARD_ID="MiniCore:avr:328:bootloader=true,variant=modelPB,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # atmega168
-
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     # clock=8MHz_internal
-    # F_CPU of 8 MHz will be fully tested for clock=8MHz_external and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
+    # F_CPU of 8 MHz has already been fully tested and the BOD and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
     - SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # AVR_examples
-    # bootloader=true, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, variant=modelNonP, BOD=4v3, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:168:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # variant=modelPB, BOD=1v8, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # Optiboot_flasher
-    # bootloader=true, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, variant=modelNonP, BOD=4v3, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:168:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # variant=modelPB, BOD=1v8, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # SoftwareSerial
-    # bootloader=true, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, variant=modelNonP, BOD=4v3, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:168:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # variant=modelPB, BOD=1v8, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # SPI
-    # bootloader=true, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, variant=modelNonP, BOD=4v3, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:168:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # variant=modelPB, BOD=1v8, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # SPI1
-    # This library is only for use with the ATmega328PB
-
-    # Wire
-    # This library is not compatible with the modelPB variant
-    # bootloader=true, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, variant=modelNonP, BOD=4v3, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:168:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # variant=modelPB, BOD=1v8, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # Wire1
-    # This library is only for use with the ATmega328PB
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:168:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
 
     # ATmega88
-
+    # bootloader=true, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # LTO=Os_flto, clock=20MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # bootloader=false, variant=modelNonP, BOD=4v3, clock=18_432MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:88:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # variant=modelPB, BOD=1v8, clock=12MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # BOD=disabled, clock=8MHz_external
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     # clock=8MHz_internal
-    # F_CPU of 8 MHz will be fully tested for clock=8MHz_external and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
+    # F_CPU of 8 MHz has already been fully tested and the BOD and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
     - SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # AVR_examples
-    # bootloader=true, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, variant=modelNonP, BOD=4v3, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:88:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # variant=modelPB, BOD=1v8, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # Optiboot_flasher
-    # bootloader=true, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, variant=modelNonP, BOD=4v3, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:88:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # variant=modelPB, BOD=1v8, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Optiboot_flasher" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # SoftwareSerial
-    # bootloader=true, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, variant=modelNonP, BOD=4v3, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:88:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # variant=modelPB, BOD=1v8, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # SPI
-    # bootloader=true, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, variant=modelNonP, BOD=4v3, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:88:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # variant=modelPB, BOD=1v8, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # SPI1
-    # This library is only for use with the ATmega328PB
-
-    # Wire
-    # bootloader=true, variant=modelP, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, variant=modelNonP, BOD=4v3, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:88:bootloader=false,variant=modelNonP,BOD=4v3,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # variant=modelPB, BOD=1v8, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelPB,BOD=1v8,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=disabled,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # Wire1
-    # This library is only for use with the ATmega328PB
+    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries" BOARD_ID="MiniCore:avr:88:bootloader=true,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
 
     # ATmega48
     # clock=8MHz_internal
@@ -354,9 +134,6 @@ env:
     # clock=1MHz_internal
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI/examples/DigitalPotControl" BOARD_ID="MiniCore:avr:48:bootloader=false,variant=modelP,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
 
-    # SPI1
-    # This library is only for use with the ATmega328PB
-
     # Wire
     # This library is not compatible with the modelPB variant
     # Compilation of SFRRanger_reader fails with LTO=Os "Sketch too big" so all tests are done with LTO=Os_flto to avoid the need to add 36 more jobs
@@ -373,10 +150,6 @@ env:
     # clock=1MHz_internal
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:48:bootloader=false,variant=modelP,BOD=2v7,LTO=Os_flto,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
 
-    # Wire1
-    # This library is only for use with the ATmega328PB
-
-
     # ATmega8
     # Compilation of an example sketch for ATmega8 fails so each library/example must be done in separate jobs
 
@@ -386,7 +159,7 @@ env:
 
     # AVR_examples
     # Blink
-    # bootloader=true, bootloader=true, BOD=2v7, LTO=Os, clock=16MHz_external
+    # bootloader=true, BOD=2v7, LTO=Os, clock=16MHz_external
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Blink" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     # LTO=Os_flto, clock=20MHz_external
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/AVR_examples/examples/Blink" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
@@ -471,40 +244,6 @@ env:
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     # clock=1MHz_internal
     - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SoftwareSerial" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # SPI
-    # bootloader=true, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, BOD=4v0, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:8:bootloader=false,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/SPI" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # SPI1
-    # This library is only for use with the modelPB variant
-
-    # Wire
-    # bootloader=true, BOD=2v7, LTO=Os, clock=16MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # LTO=Os_flto, clock=20MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # bootloader=false, BOD=4v0, clock=18_432MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:8:bootloader=false,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # BOD=disabled, clock=12MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=8MHz_external
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=1MHz_internal
-    - SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MiniCore/avr/libraries/Wire" BOARD_ID="MiniCore:avr:8:bootloader=true,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-
-    # Wire1
-    # This library is only for use with the modelPB variant
 
 
 before_install:


### PR DESCRIPTION
- Remove builds of SPI1 and Wire1 examples.
- Add missing library builds for ATmega48 and ATmega8.