### PR TITLE
Wrong upload baud rate for 8Mhz

### DIFF
--- a/PlatformIO.md
+++ b/PlatformIO.md
@@ -99,7 +99,7 @@ Below is a table with the default clocks and baud rates for MiniCore:
 | 18.432 MHz  | External   | 18432000L         | 115200             |
 | 16 MHz      | External   | 16000000L         | 115200             |
 | 12 MHz      | External   | 12000000L         | 57600              |
-| 8 MHz       | External   | 8000000L          | 57600              |
+| 8 MHz       | External   | 8000000L          | 38400              |
 | 8 MHz       | Internal   | 8000000L          | 38400              |
 | 1 MHz       | Internal   | 1000000L          | 9600               |
 


### PR DESCRIPTION
Both https://github.com/MCUdude/MiniCore/blob/master/avr/boards.txt#L135 and actual experience with it not working at 57600 but at 38400 indicates this is wrong.

I take it setting `board_upload.speed = 38400` is required if not running at 16Mhz - it doesn't auto-detect based on `board_build.f_cpu = 8000000L`?