### PR TITLE
Feature correct millis

### DIFF
--- a/avr/cores/MCUdude_corefiles/wiring.c
+++ b/avr/cores/MCUdude_corefiles/wiring.c
@@ -48,6 +48,43 @@ volatile unsigned long timer0_overflow_count = 0;
 volatile unsigned long timer0_millis = 0;
 static unsigned char timer0_fract = 0;
 
+// Add a correction calculation to make millis () exact for certain clocks.
+// The idea is to compare the exact microseconds/8 between overflows,
+// namely (1. / F_CPU * 64. * 256. * 1e6) % 1000 / 8.,
+// with the integer rounded down version in FRACT_INC.
+// For the clock speeds examined below, we encounter three different cases.
+// The low case: FRACT_INC is too low by a fraction 1 / n.
+//               Correct by adding 1 to the fract counter every n times.
+// The high case: FRACT_INC is too low by a fraction (n - 1) / n.
+//               Add 1 to the fract counter always except every n times.
+// A special case for 20 MHz: FRACT_INC is too low by the fraction 2. / 5.
+//               Correct by adding 2 out of 5 times: every odd number in 0..4.
+// This way we correct losses from both the rounding to usecs and the shift.
+#if F_CPU == 20000000L || \
+    F_CPU == 18432000L || \
+    F_CPU == 14745600L || \
+    F_CPU == 12000000L || \
+    F_CPU ==  1843200L
+#define CORRECT_EXACT
+static unsigned char correct_exact = 0;
+#if F_CPU == 20000000L          // for 20 MHz we get 102.4, off by 2./5.
+#define CORRECT_ODD
+#define CORRECT_ROLL 5
+#elif F_CPU == 18432000L        // for 18.432 MHz we get 111.11, off by 1./9.
+#define CORRECT_LO
+#define CORRECT_ROLL 9
+#elif F_CPU == 14745600L        // for 14.7456 MHz we get 13.89, off by 8./9.
+#define CORRECT_HI
+#define CORRECT_ROLL 9
+#elif F_CPU == 12000000L        // for 12 MHz we get 45.67, off by 2./3.
+#define CORRECT_HI
+#define CORRECT_ROLL 3
+#elif F_CPU == 1843200L         // for 1.8432 MHz we get 111.11, off by 1./9.
+#define CORRECT_LO
+#define CORRECT_ROLL 9
+#endif
+#endif
+
 // timer0 interrupt routine ,- is called every time timer0 overflows
 #if defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__)
 ISR(TIM0_OVF_vect)
@@ -62,6 +99,27 @@ ISR(TIMER0_OVF_vect)
 
   m += MILLIS_INC;
   f += FRACT_INC;
+
+#ifdef CORRECT_EXACT
+  // correct millis () to be exact for certain clocks
+  if (++correct_exact == CORRECT_ROLL) {
+        correct_exact = 0;
+#ifdef CORRECT_LO
+    ++f;
+#endif
+  }
+#ifdef CORRECT_HI
+  else {
+    ++f;
+  }
+#endif
+#ifdef CORRECT_ODD
+  if (correct_exact & 1) {
+    ++f;
+  }
+#endif
+#endif // CORRECT_EXACT
+
   if (f >= FRACT_MAX) {
     f -= FRACT_MAX;
     m += 1;


### PR DESCRIPTION
Hi, thanks for maintaining this core! Works well for me.

I've looked into millis () and added corrections to make it exact for all two-digit MHz speeds.
The cost is adding one unsigned char counter that is incremented in the timer interrupt.