### PR TITLE
Fix the TwoWire destructor to use the array delete operator

### DIFF
--- a/avr/libraries/Wire/src/Wire.cpp
+++ b/avr/libraries/Wire/src/Wire.cpp
@@ -379,8 +379,8 @@ TwoWire::TwoWire(int bufferLength,
 
 TwoWire::~TwoWire()
 {
-  delete rxBuffer;
-  delete txBuffer;
+  delete[] rxBuffer;
+  delete[] txBuffer;
 }
 
 // Public Methods //////////////////////////////////////////////////////////////


### PR DESCRIPTION
The `TwoWire::~TwoWire()` destructor should use `delete[]` and not `delete` to correspond with the `new uint8_t[bufferLength]` in the constructor.  It was mostly working by accident since the TwoWire objects are generally created globally and never destroyed.  But depending on the library usage, having this wrong either causes the wrong operator to get called or link errors for a missing `operator delete(void *, size_t)` to be generated.