### PR TITLE
Better explanation for uploading sketches

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Ok, so you're downloaded and installed MiniCore, but how to get started? Here's 
 * Hit **Burn Bootloader**. If an LED is connected to pin PB5 (Arduino pin 13), it should flash twice every second.
 * Now that the correct fuse settings is sat and the bootloader burnt, you can upload your code in two ways:
 	- Disconnect your programmer tool, and connect a USB to serial adapter to the microcontroller, like shown in the [minimal setup circuit](#minimal-setup). Then select the correct serial port under the **Tools** menu, and click the **Upload** button. If you're getting some kind of timeout error, it means your RX and TX pins are swapped, or your auto reset circuity isn't working properly (the 100 nF capacitor on the reset line).
-	- Keep your programmer connected, and hold down the `shift` button while clicking **Upload**. This will erase the bootloader and upload your code using the programmer tool.
+	- Use the option **Sketch > Upload Using Programmer**, this will erase the bootloader and upload your code using the programmer tool.
 
 Your code should now be running on your microcontroller! If you experience any issues related to bootloader burning or serial uploading, please use *[this forum post](https://forum.arduino.cc/index.php?topic=412070.0)* or create an issue on Github.
 


### PR DESCRIPTION
Changed the explanation for uploading a sketch because the shortcut (SHIFT + Upload) doesn't work on linux, and using the menu is more straight forward