### PR TITLE
Support 4.9152MHz clock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode

--- a/avr/boards.txt
+++ b/avr/boards.txt
@@ -1020,6 +1020,12 @@ menu.baudrate=Baud rate
 8.menu.clock.6MHz_external.bootloader.ckopt_bit=0
 8.menu.clock.6MHz_external.build.f_cpu=6000000L
 
+8.menu.clock.4_9152MHz_external=External 4.9152 MHz
+8.menu.clock.4_9152MHz_external.upload.default_speed=38400
+8.menu.clock.4_9152MHz_external.bootloader.sut_cksel_bits=111111
+8.menu.clock.4_9152MHz_external.bootloader.ckopt_bit=0
+8.menu.clock.4_9152MHz_external.build.f_cpu=4915200L
+
 8.menu.clock.4MHz_external=External 4 MHz
 8.menu.clock.4MHz_external.upload.default_speed=9600
 8.menu.clock.4MHz_external.bootloader.sut_cksel_bits=111111

--- a/avr/cores/MCUdude_corefiles/wiring.c
+++ b/avr/cores/MCUdude_corefiles/wiring.c
@@ -126,6 +126,9 @@ volatile unsigned char timer0_fract = 0;
 #elif F_CPU == 6000000L         // for 6 MHz we get 91 + 1./3.
 #define CORRECT_LO
 #define CORRECT_ROLL 3
+#elif F_CPU == 4915200L         // for 4.9152 MHz we get 41.67, off by 2./3.
+#define CORRECT_HI
+#define CORRECT_ROLL 3
 #elif F_CPU == 3686400L         // for 3.6864 MHz we get 55 + 5./9.
 #define CORRECT_BRUTE 5
 #define CORRECT_ROLL 9


### PR DESCRIPTION
Add support for 4.9152MHz clock which also provides error free UART for certain baud rates like 38400