### PR TITLE
dw-tools 2.2.0

### DIFF
--- a/Add_dw-tools-release.sh
+++ b/Add_dw-tools-release.sh
@@ -3,7 +3,7 @@
 AUTHOR=MCUdude  # Github username
 REPOSITORY=MiniCore # Github repo name
 
-DWTOOLS_VERSION="2.1.8"
+DWTOOLS_VERSION="2.2.0"
 
 OS_PLATFORM1="Linux_ARMv6"
 OS_PLATFORM2="Linux_ARM64"

--- a/Boards_manager_release.sh
+++ b/Boards_manager_release.sh
@@ -13,7 +13,7 @@ AUTHOR=MCUdude       # Github username
 REALAUTHOR=MCUdude       # real author!
 REPOSITORY=MiniCore      # Github repo
 
-DWTOOLSVERSION=2.1.8
+DWTOOLSVERSION=2.2.0
 
 # Get the download URL for the latest release from Github
 DOWNLOAD_URL=$(curl -s https://api.github.com/repos/$AUTHOR/$REPOSITORY/releases/latest | grep "tarball_url" | awk -F\" '{print $4}')


### PR DESCRIPTION
Updated dw-tools (a new library of "live" tests and three minor bug fixes) to v2.2.0.

You just need to create a new release (3.1.2?), run ./Add_dw-tools-release.sh, and after that ./Boards_manager_release.sh.

Cheers,
Bernhard

