### PR TITLE
new dw-tools: 2.2.1

### DIFF
--- a/Add_dw-tools-release.sh
+++ b/Add_dw-tools-release.sh
@@ -3,7 +3,7 @@
 AUTHOR=MCUdude  # Github username
 REPOSITORY=MiniCore # Github repo name
 
-DWTOOLS_VERSION="2.2.0"
+DWTOOLS_VERSION="2.2.1"
 
 OS_PLATFORM1="Linux_ARMv6"
 OS_PLATFORM2="Linux_ARM64"
@@ -12,6 +12,7 @@ OS_PLATFORM4="Linux_64bit"
 OS_PLATFORM5="Linux_32bit"
 OS_PLATFORM6="Windows_64bit"
 OS_PLATFORM7="macOS_ARM64"
+OS_PLATFORM8="Windows_32bit"
 
 HOST1="arm-linux-gnueabihf"
 HOST2="aarch64-linux-gnu"
@@ -20,6 +21,7 @@ HOST4="x86_64-linux-gnu"
 HOST5="i686-linux-gnu"
 HOST6="x86_64-mingw32"
 HOST7="arm64-apple-darwin"
+HOST8="i686-mingw32"
 
 FILE1=dw-tools-${DWTOOLS_VERSION}_${HOST1}.tar.bz2
 FILE2=dw-tools-${DWTOOLS_VERSION}_${HOST2}.tar.bz2
@@ -28,6 +30,8 @@ FILE4=dw-tools-${DWTOOLS_VERSION}_${HOST4}.tar.bz2
 FILE5=dw-tools-${DWTOOLS_VERSION}_${HOST5}.tar.bz2
 FILE6=dw-tools-${DWTOOLS_VERSION}_${HOST6}.tar.bz2
 FILE7=dw-tools-${DWTOOLS_VERSION}_${HOST7}.tar.bz2
+FILE8=dw-tools-${DWTOOLS_VERSION}_${HOST8}.tar.bz2
+
 
 URL1=https://felias-fogg.github.io/dw-tools/${FILE1}
 URL2=https://felias-fogg.github.io/dw-tools/${FILE2}
@@ -36,81 +40,109 @@ URL4=https://felias-fogg.github.io/dw-tools/${FILE4}
 URL5=https://felias-fogg.github.io/dw-tools/${FILE5}
 URL6=https://felias-fogg.github.io/dw-tools/${FILE6}
 URL7=https://felias-fogg.github.io/dw-tools/${FILE7}
+URL8=https://felias-fogg.github.io/dw-tools/${FILE8}
 
 # Download files
-#wget --no-verbose $URL1
+wget --no-verbose $URL1
 wget --no-verbose $URL2
 wget --no-verbose $URL3
 wget --no-verbose $URL4
-#wget --no-verbose $URL5
+wget --no-verbose $URL5
 wget --no-verbose $URL6
 wget --no-verbose $URL7
+wget --no-verbose $URL8
 
-#SIZE1=$(wc -c $FILE1 | awk '{print $1}')
+SIZE1=$(wc -c $FILE1 | awk '{print $1}')
 SIZE2=$(wc -c $FILE2 | awk '{print $1}')
 SIZE3=$(wc -c $FILE3 | awk '{print $1}')
 SIZE4=$(wc -c $FILE4 | awk '{print $1}')
-#SIZE5=$(wc -c $FILE5 | awk '{print $1}')
+SIZE5=$(wc -c $FILE5 | awk '{print $1}')
 SIZE6=$(wc -c $FILE6 | awk '{print $1}')
 SIZE7=$(wc -c $FILE7 | awk '{print $1}')
+SIZE8=$(wc -c $FILE8 | awk '{print $1}')
 
-#SHASUM1=$(shasum -a 256 $FILE1 | awk '{print "SHA-256:"$1}')
+SHASUM1=$(shasum -a 256 $FILE1 | awk '{print "SHA-256:"$1}')
 SHASUM2=$(shasum -a 256 $FILE2 | awk '{print "SHA-256:"$1}')
 SHASUM3=$(shasum -a 256 $FILE3 | awk '{print "SHA-256:"$1}')
 SHASUM4=$(shasum -a 256 $FILE4 | awk '{print "SHA-256:"$1}')
-#SHASUM5=$(shasum -a 256 $FILE5 | awk '{print "SHA-256:"$1}')
+SHASUM5=$(shasum -a 256 $FILE5 | awk '{print "SHA-256:"$1}')
 SHASUM6=$(shasum -a 256 $FILE6 | awk '{print "SHA-256:"$1}')
 SHASUM7=$(shasum -a 256 $FILE7 | awk '{print "SHA-256:"$1}')
+SHASUM8=$(shasum -a 256 $FILE8 | awk '{print "SHA-256:"$1}')
 
-#printf "File1: ${FILE1}, Size: ${SIZE1}, SHA256: ${SHASUM1}, URL1: ${URL1}\n"
+printf "File1: ${FILE1}, Size: ${SIZE1}, SHA256: ${SHASUM1}, URL1: ${URL1}\n"
 printf "File2: ${FILE2}, Size: ${SIZE2}, SHA256: ${SHASUM2}, URL2: ${URL2}\n"
 printf "File3: ${FILE3}, Size: ${SIZE3}, SHA256: ${SHASUM3}, URL3: ${URL3}\n"
 printf "File4: ${FILE4}, Size: ${SIZE4}, SHA256: ${SHASUM4}, URL4: ${URL4}\n"
-#printf "File5: ${FILE5}, Size: ${SIZE5}, SHA256: ${SHASUM5}, URL5: ${URL5}\n"
+printf "File5: ${FILE5}, Size: ${SIZE5}, SHA256: ${SHASUM5}, URL5: ${URL5}\n"
 printf "File6: ${FILE6}, Size: ${SIZE6}, SHA256: ${SHASUM6}, URL6: ${URL6}\n"
 printf "File7: ${FILE7}, Size: ${SIZE7}, SHA256: ${SHASUM7}, URL7: ${URL7}\n"
+printf "File8: ${FILE8}, Size: ${SIZE8}, SHA256: ${SHASUM8}, URL7: ${URL8}\n"
 
 cp "package_${AUTHOR}_${REPOSITORY}_index.json" "package_${AUTHOR}_${REPOSITORY}_index.json.tmp"
 
-### NOTE: OS platform 5 needs to be added!
-
 jq -r                                  \
 --arg dwtools_version $DWTOOLS_VERSION \
+--arg os_plaform1 $OS_PLATFORM1 \
 --arg os_plaform2 $OS_PLATFORM2 \
 --arg os_plaform3 $OS_PLATFORM3 \
 --arg os_plaform4 $OS_PLATFORM4 \
+--arg os_plaform5 $OS_PLATFORM5 \
 --arg os_plaform6 $OS_PLATFORM6 \
 --arg os_plaform7 $OS_PLATFORM7 \
+--arg os_plaform8 $OS_PLATFORM8 \
+--arg host1       $HOST1        \
 --arg host2       $HOST2        \
 --arg host3       $HOST3        \
 --arg host4       $HOST4        \
+--arg host5       $HOST5        \
 --arg host6       $HOST6        \
 --arg host7       $HOST7        \
+--arg host8       $HOST8        \
+--arg file1       $FILE1        \
 --arg file2       $FILE2        \
 --arg file3       $FILE3        \
 --arg file4       $FILE4        \
+--arg file5       $FILE5        \
 --arg file6       $FILE6        \
 --arg file7       $FILE7        \
+--arg file8       $FILE8        \
+--arg size1       $SIZE1        \
 --arg size2       $SIZE2        \
 --arg size3       $SIZE3        \
 --arg size4       $SIZE4        \
+--arg size5       $SIZE5        \
 --arg size6       $SIZE6        \
 --arg size7       $SIZE7        \
+--arg size8       $SIZE8        \
+--arg shasum1     $SHASUM1      \
 --arg shasum2     $SHASUM2      \
 --arg shasum3     $SHASUM3      \
 --arg shasum4     $SHASUM4      \
+--arg shasum5     $SHASUM5      \
 --arg shasum6     $SHASUM6      \
 --arg shasum7     $SHASUM7      \
+--arg shasum8     $SHASUM8      \
+--arg url1        $URL1         \
 --arg url2        $URL2         \
 --arg url3        $URL3         \
 --arg url4        $URL4         \
+--arg url5        $URL5         \
 --arg url6        $URL6         \
 --arg url7        $URL7         \
+--arg url8        $URL8         \
 '.packages[].tools[.packages[].tools | length] |= . +
 {
   "name": "dw-tools",
   "version": $dwtools_version,
   "systems": [
+    {
+      "size": $size1,
+      "checksum": $shasum1,
+      "host": $host1,
+      "archiveFileName": $file1,
+      "url": $url1
+    },
     {
       "size": $size2,
       "checksum": $shasum2,
@@ -133,6 +165,13 @@ jq -r                                  \
       "url": $url4
     },
     {
+      "size": $size5,
+      "checksum": $shasum5,
+      "host": $host5,
+      "archiveFileName": $file5,
+      "url": $url5
+    },
+    {
       "size": $size6,
       "checksum": $shasum6,
       "host": $host6,
@@ -145,17 +184,25 @@ jq -r                                  \
       "host": $host7,
       "archiveFileName": $file7,
       "url": $url7
+    },
+    {
+      "size": $size8,
+      "checksum": $shasum8,
+      "host": $host8,
+      "archiveFileName": $file8,
+      "url": $url8
     }
   ]
 }' "package_${AUTHOR}_${REPOSITORY}_index.json.tmp" > "package_${AUTHOR}_${REPOSITORY}_index.json"
 
-#rm $FILE1
+rm $FILE1
 rm $FILE2
 rm $FILE3
 rm $FILE4
-#rm $FILE5
+rm $FILE5
 rm $FILE6
 rm $FILE7
+rm $FILE8
 rm "package_${AUTHOR}_${REPOSITORY}_index.json.tmp"
 
 

--- a/Boards_manager_release.sh
+++ b/Boards_manager_release.sh
@@ -13,7 +13,7 @@ AUTHOR=MCUdude       # Github username
 REALAUTHOR=MCUdude       # real author!
 REPOSITORY=MiniCore      # Github repo
 
-DWTOOLSVERSION=2.2.0
+DWTOOLSVERSION=2.2.1
 
 # Get the download URL for the latest release from Github
 DOWNLOAD_URL=$(curl -s https://api.github.com/repos/$AUTHOR/$REPOSITORY/releases/latest | grep "tarball_url" | awk -F\" '{print $4}')


### PR DESCRIPTION
For all 32-bit OSs, dummy tools are included that simply give an informative error message. This is in particular important when you install the package using the legacy IDE under Windows and then later switch to Arduino IDE 2 (see screen shot). A simple reinstall solves this problem (see second screen shot).

![no32bit](https://github.com/user-attachments/assets/39b0cc46-9286-4d27-bfd9-40d640874983)
![64bit](https://github.com/user-attachments/assets/0eae1876-d18c-4c9f-a382-b76e692ceafa)
